### PR TITLE
Add an Etag header for the request

### DIFF
--- a/controller/endpointcontroller.php
+++ b/controller/endpointcontroller.php
@@ -77,7 +77,9 @@ class EndpointController extends Controller {
 			$data[] = $this->notificationToArray($notificationId, $notification);
 		}
 
-		return new JSONResponse($data);
+		$response = new JSONResponse($data);
+		$response->setETag($this->generateEtag($notifications));
+		return $response;
 	}
 
 	/**
@@ -89,6 +91,16 @@ class EndpointController extends Controller {
 	public function delete($id) {
 		$this->handler->deleteById($id, $this->user);
 		return new Response();
+	}
+
+	/**
+	 * Get an Etag for the notification ids
+	 * @param array $notifications
+	 * @return string
+	 */
+	protected function generateEtag(array $notifications) {
+		$ids = array_keys($notifications);
+		return md5(json_encode($ids));
 	}
 
 	/**

--- a/tests/controller/EndpointControllerTest.php
+++ b/tests/controller/EndpointControllerTest.php
@@ -93,7 +93,7 @@ class EndpointControllerTest extends TestCase {
 	public function dataGet() {
 		return [
 			[
-				[], [],
+				[], md5(json_encode([])), [],
 			],
 			[
 				[
@@ -104,6 +104,7 @@ class EndpointControllerTest extends TestCase {
 						->disableOriginalConstructor()
 						->getMock(),
 				],
+				md5(json_encode([1, 3])),
 				['$notification', '$notification'],
 			],
 			[
@@ -112,6 +113,7 @@ class EndpointControllerTest extends TestCase {
 						->disableOriginalConstructor()
 						->getMock(),
 				],
+				md5(json_encode([42])),
 				['$notification'],
 			],
 		];
@@ -120,9 +122,10 @@ class EndpointControllerTest extends TestCase {
 	/**
 	 * @dataProvider dataGet
 	 * @param array $notifications
+	 * @param string $expectedETag
 	 * @param array $expectedData
 	 */
-	public function testGet(array $notifications, array $expectedData) {
+	public function testGet(array $notifications, $expectedETag, array $expectedData) {
 		$controller = $this->getController([
 			'notificationToArray',
 		]);
@@ -152,6 +155,7 @@ class EndpointControllerTest extends TestCase {
 		$response = $controller->get();
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 
+		$this->assertSame($expectedETag, $response->getETag());
 		$this->assertSame($expectedData, $response->getData());
 	}
 


### PR DESCRIPTION
@guruz the header is currently e.g.:
```
"769b302348905574f8588008f86d19ce"
```
Due to strange behaviour in [core](https://github.com/owncloud/core/blame/34f5541088e99367a8bcdc1ca2ba4fa8524eec68/lib/public/appframework/http/response.php#L220), but you can still just keep an eye on that string. it's just longer then 32chars.

Fix #2 