### PR TITLE
Stop polling when app is disabled

### DIFF
--- a/controller/endpointcontroller.php
+++ b/controller/endpointcontroller.php
@@ -25,6 +25,7 @@ use OC\Notification\IAction;
 use OC\Notification\IManager;
 use OC\Notification\INotification;
 use OCA\Notifications\Handler;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Response;
@@ -65,6 +66,14 @@ class EndpointController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function get() {
+		// When there are no apps registered that use the notifications
+		// We stop polling for them.
+		if (!$this->manager->hasNotifiers()) {
+			$response = new Response();
+			$response->setStatus(Http::STATUS_NOT_FOUND);
+			return $response;
+		}
+
 		$filter = $this->manager->createNotification();
 		$filter->setUser($this->user);
 		$language = $this->config->getUserValue($this->user, 'core', 'lang', null);

--- a/tests/controller/EndpointControllerTest.php
+++ b/tests/controller/EndpointControllerTest.php
@@ -141,6 +141,9 @@ class EndpointControllerTest extends TestCase {
 			->willReturn('username');
 
 		$this->manager->expects($this->once())
+			->method('hasNotifiers')
+			->willReturn(true);
+		$this->manager->expects($this->once())
 			->method('createNotification')
 			->willReturn($filter);
 		$this->manager->expects($this->exactly(sizeof($notifications)))
@@ -198,12 +201,15 @@ class EndpointControllerTest extends TestCase {
 			->willReturn('username');
 
 		$this->manager->expects($this->once())
+			->method('hasNotifiers')
+			->willReturn(true);
+		$this->manager->expects($this->once())
 			->method('createNotification')
 			->willReturn($filter);
-		$this->manager->expects($this->at(1))
+		$this->manager->expects($this->at(2))
 			->method('prepare')
 			->willThrowException(new \InvalidArgumentException());
-		$this->manager->expects($this->at(2))
+		$this->manager->expects($this->at(3))
 			->method('prepare')
 			->willReturnArgument(0);
 
@@ -217,6 +223,18 @@ class EndpointControllerTest extends TestCase {
 
 		$this->assertSame($expectedETag, $response->getETag());
 		$this->assertSame($expectedData, $response->getData());
+	}
+
+	public function testGetNoNotifiers() {
+		$controller = $this->getController();
+		$this->manager->expects($this->once())
+			->method('hasNotifiers')
+			->willReturn(false);
+
+		$response = $controller->get();
+		$this->assertInstanceOf('OCP\AppFramework\Http\Response', $response);
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
 
 	public function dataDelete() {


### PR DESCRIPTION
- [ ]  Depends on https://github.com/owncloud/core/pull/19092

This hides the :bell: when no app wants to use notifications :cry: 

@PVince81 @karlitschek as discussed