### PR TITLE
Do not enable Notifications on the login/ pages

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -37,7 +37,8 @@ use OCP\Util;
 $request = \OC::$server->getRequest();
 if (\OC::$server->getUserSession()->getUser() !== null
 	&& substr($request->getScriptName(), 0 - strlen('/index.php')) === '/index.php'
-	&& substr($request->getPathInfo(), 0, strlen('/s/')) !== '/s/') {
+	&& substr($request->getPathInfo(), 0, strlen('/s/')) !== '/s/'
+	&& substr($request->getPathInfo(), 0, strlen('/login/')) !== '/login/') {
 	Util::addScript('notifications', 'app');
 	Util::addScript('notifications', 'notification');
 	Util::addStyle('notifications', 'styles');

--- a/tests/Unit/AppInfo/AppTest.php
+++ b/tests/Unit/AppInfo/AppTest.php
@@ -89,6 +89,7 @@ class AppTest extends TestCase {
 			['/index.php', '/apps/files', null, false],
 			['/remote.php', '/webdav', $user, false],
 			['/index.php', '/s/1234567890123', $user, false],
+			['/index.php', '/login/selectchallenge', $user, false],
 		];
 	}
 


### PR DESCRIPTION
### Steps
1. Enable `Notifications` and `Two Factor Test Provider`
2. Login
3. Do **not** solve the 2FA thing yet

### Expected
Page is displayed

### Actually
Page reloads all few seconds.

@ChristophWurst mind reviewing ? ;)