### PR TITLE
No hardcoded img to support theming

### DIFF
--- a/js/notification.js
+++ b/js/notification.js
@@ -130,7 +130,7 @@
 				// TODO create event handler on click for given action type
 			});
 			el.append(actions);
-			el.append('<div style="display: none;" class="notification-delete"><img class="svg" alt="' + t('notifications', 'Dismiss') + '" src="' + OC.imagePath('core', 'actions/close') + '"></div>');
+			el.append('<div style="display: none;" class="notification-delete"><div class="icon icon-close svg" alt="' + t('notifications', 'Dismiss') + '"></div></div>');
 			return el;
 		},
 


### PR DESCRIPTION
Tested on OC9 and OC10, no difference to see compared to hard coded `<img>`. Please never use these elements ever again, since theming should be possible (and be done) thru CSS, not JS.