### PR TITLE
Don't escape link text title

### DIFF
--- a/js/notification.js
+++ b/js/notification.js
@@ -170,7 +170,7 @@
 				var $link = $('<a>', {
 					'class' : cssNameSpace + '-link',
 					'href'  : this.getLink(),
-					'text'  : escapeHTML(this.getSubject())
+					'text'  : this.getSubject()
 				});
 
 				// Replace title content with link


### PR DESCRIPTION
1. Setup customgroups app
1. Create custom group "test"
1. Create a user "user1"
1. Add user "user1" to custom group "test"
1. Login as "user1"
1. Check notification

Before this fix: the title was escaped and appeared with `&quot;`
After this fix: no escaping, proper display

Since we're using jquery's `text` here it will already render as plain text and no escaping is needed.
