### PR TITLE
Correctly match the login url

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -49,7 +49,7 @@ $request = \OC::$server->getRequest();
 if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->getUser() !== null
 	&& substr($request->getScriptName(), 0 - strlen('/index.php')) === '/index.php'
 	&& substr($request->getPathInfo(), 0, strlen('/s/')) !== '/s/'
-	&& substr($request->getPathInfo(), 0, strlen('/login/')) !== '/login/') {
+	&& substr($request->getPathInfo(), 0, strlen('/login')) !== '/login') {
 	Util::addScript('notifications', 'app');
 	Util::addScript('notifications', 'notification');
 	Util::addStyle('notifications', 'styles');


### PR DESCRIPTION
This is required to correctly match the logic URL when use with SAML - to avoid a redirect loop caused by including the notifications app on the login page.