### PR TITLE
[stable10] Only test against core stable10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 env:
   global:
-    - CORE_BRANCH=master
+    - CORE_BRANCH=stable10
     - APP_NAME=notifications
   matrix:
     - DB=sqlite
@@ -74,8 +74,6 @@ matrix:
     - php: 5.6
       env: DB=mysql
     - php: 5.6
-      env: DB=mysql CORE_BRANCH=stable10
-    - php: 5.6
       env: DB=pgsql
     - php: 5.6
       env: DB=mysql CODECHECK=1
@@ -83,8 +81,6 @@ matrix:
       env: DB=mysql CODECHECK=2
     - php: 5.6
       env: DB=mysql INTEGRATION=1
-    - php: 5.6
-      env: DB=mysql INTEGRATION=1 CORE_BRANCH=stable10
 #    - php: 5.4
 #      env: DB=mysql;JSTESTS=1
   allow_failures:


### PR DESCRIPTION
This is the ``stable10`` branch of ``notifications``. It is only valid to test it against ``stable10`` in ``core``. Testing against ``core`` ``master`` is no longer going to work because that has moved on.