### PR TITLE
Standardize addPSR4 target folder format

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 $classLoader = new \Composer\Autoload\ClassLoader();
-$classLoader->addPsr4("TestHelpers\\", __DIR__. "/../../../../../../tests/TestHelpers/", true);
+$classLoader->addPsr4("TestHelpers\\", __DIR__. "/../../../../../../tests/TestHelpers", true);
 $classLoader->register();


### PR DESCRIPTION
Remove the trailing slash just to make it the same format as elsewhere.

It might avoid some confusion in future, by having the format of all these ``addPSR4`` calls the same.

It works with or without the trailing ``/``