### PR TITLE
Apiv2

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,8 +39,41 @@ return [
 	],
 
 	'routes' => [
-		['name' => 'NotificationOptions#getNotificationOptions', 'url' => '/settings/personal/notifications/options', 'verb' => 'GET'],
-		['name' => 'NotificationOptions#setNotificationOptions', 'url' => '/settings/personal/notifications/options', 'verb' => 'PUT'],
-		['name' => 'NotificationOptions#setNotificationOptionsPartial', 'url' => '/settings/personal/notifications/options', 'verb' => 'PATCH'],
-	],
+		[
+			'name' => 'NotificationOptions#getNotificationOptions',
+			'url' => '/settings/personal/notifications/options',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'NotificationOptions#setNotificationOptions',
+			'url' => '/settings/personal/notifications/options',
+			'verb' => 'PUT'
+		],
+		[
+			'name' => 'NotificationOptions#setNotificationOptionsPartial',
+			'url' => '/settings/personal/notifications/options',
+			'verb' => 'PATCH'
+		],
+
+		[
+			'name' => 'EndpointV2#listNotifications',
+			'url' => '/api/v2/notifications',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'EndpointV2#getNotification',
+			'url' => '/api/v2/notifications/{id}',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'EndpointV2#deleteNotification',
+			'url' => '/api/v2/notifications/{id}',
+			'verb' => 'DELETE'
+		],
+		[
+			'name' => 'EndpointV2#getLastNotificationId',
+			'url' => '/api/v2/tracker/notifications/polling',
+			'verb' => 'GET'
+		],
+	]
 ];

--- a/css/styles.css
+++ b/css/styles.css
@@ -26,6 +26,14 @@
 	font-size: 16px;
 }
 
+.notification-container .notification-controls {
+	text-align: center;
+}
+
+.notification-container .notification-controls button {
+	display: inline;
+}
+
 /* Fill width on mobile */
 @media (max-width: 500px) {
 	.notification-container {

--- a/js/app.js
+++ b/js/app.js
@@ -60,11 +60,11 @@
 			// Initial call to the notification endpoint
 			var self = this;
 			this.fetchDescendentV2(
-				OC.generateUrl('apps/notifications/api/v2/notifications?limit=3'),
+				OC.generateUrl('apps/notifications/api/v2/notifications?limit=3&format=json'),
 				function(result, textStatus, jqxhr) {
 					self.updateLastKnowId(jqxhr.getResponseHeader('OC-Last-Notification'));
-					if (result.data.length > 0) {
-						self.updateLastShownId(result.data[0].notification_id);
+					if (result.ocs.data.notifications.length > 0) {
+						self.updateLastShownId(result.ocs.data.notifications[0].notification_id);
 					}
 			});
 
@@ -178,13 +178,13 @@
 				type: 'GET'
 			}).done(function(result, textStatus, jqxhr) {
 					// Fill Array
-					$.each(result.data, function(index) {
-						var n = new self.Notif(result.data[index]);
+					$.each(result.ocs.data.notifications, function(index) {
+						var n = new self.Notif(result.ocs.data.notifications[index]);
 						self.notifications[n.getId()] = n;
 						self.appendToUI(n);
 					});
-					if (typeof result.next !== 'undefined') {
-						self.addShowMoreNotificationsButton(result.next);
+					if (typeof result.ocs.data.next !== 'undefined') {
+						self.addShowMoreNotificationsButton(result.ocs.data.next);
 					}
 					// Check if we have any, and notify the UI
 					if (self.numNotifications() !== 0) {
@@ -221,13 +221,13 @@
 				type: 'GET'
 			}).done(function(result, textStatus, jqxhr){
 					// Fill Array
-					$.each(result.data, function(index) {
-						var n = new self.Notif(result.data[index]);
+					$.each(result.ocs.data.notifications, function(index) {
+						var n = new self.Notif(result.ocs.data.notifications[index]);
 						self.notifications[n.getId()] = n;
 						self.addToUI(n);
 					});
-					if (typeof result.next !== 'undefined') {
-						self.addShowNewerNotificationsButton(result.next);
+					if (typeof result.ocs.data.next !== 'undefined') {
+						self.addShowNewerNotificationsButton(result.ocs.data.next);
 					}
 					// Check if we have any, and notify the UI
 					if (self.numNotifications() !== 0) {
@@ -255,7 +255,7 @@
 		pollingV2: function() {
 			var self = this;
 			var request = $.ajax({
-				url: OC.generateUrl('apps/notifications/api/v2/tracker/notifications/polling'),
+				url: OC.generateUrl('apps/notifications/api/v2/tracker/notifications/polling?format=json'),
 				type: 'GET'
 			}).done(function(result, textStatus, jqxhr){
 				var lastNotificationId = jqxhr.getResponseHeader('OC-Last-Notification');
@@ -310,7 +310,7 @@
 				// if we don't know the id shown, rely on the stored one
 				lastShownId = this.getLastShownId();
 			}
-			var targetUrl = OC.generateUrl('apps/notifications/api/v2/notifications?id=' + lastShownId + '&fetch=asc&limit=3');
+			var targetUrl = OC.generateUrl('apps/notifications/api/v2/notifications?id=' + lastShownId + '&fetch=asc&limit=3&format=json');
 			this.addShowNewerNotificationsButton(targetUrl);
 		},
 

--- a/js/app.js
+++ b/js/app.js
@@ -32,11 +32,13 @@
 
 		interval: null,
 
+		lastKnownId: null,
+
 		initialise: function() {
 			// Go!
 
 			// Setup elements
-			this.$notifications = $('<div class="notifications hidden"></div>');
+			this.$notifications = $('<div class="notifications"></div>');
 			this.$button = $('<div class="notifications-button menutoggle"><img class="svg" alt="' + t('notifications', 'Notifications') + '" src="' + OC.imagePath('notifications', 'notifications') + '"></div>');
 			this.$container = $('<div class="notification-container"></div>');
 			var $wrapper = $('<div class="notification-wrapper"></div>');
@@ -56,7 +58,15 @@
 			$('form.searchbox').before(this.$notifications);
 
 			// Initial call to the notification endpoint
-			this.initialFetch();
+			var self = this;
+			this.fetchDescendentV2(
+				OC.generateUrl('apps/notifications/api/v2/notifications?limit=3'),
+				function(result, textStatus, jqxhr) {
+					self.updateLastKnowId(jqxhr.getResponseHeader('OC-Last-Notification'));
+					if (result.data.length > 0) {
+						self.updateLastShownId(result.data[0].notification_id);
+					}
+			});
 
 			// Bind the button click event
 			OC.registerMenu(this.$button, this.$container);
@@ -66,7 +76,11 @@
 			this.$container.on('click', '.notification-delete', _.bind(this._onClickDismissNotification, this));
 
 			// Setup the background checker
-			this.interval = setInterval(_.bind(this.backgroundFetch, this), this.pollInterval);
+			this.restartPolling();
+
+			if ('Notification' in window && Notification.permission === 'default') {
+				Notification.requestPermission();
+			}
 		},
 
 		_onClickDismissNotification: function(event) {
@@ -79,7 +93,7 @@
 			$notification.fadeOut(OC.menuSpeed);
 
 			$.ajax({
-				url: OC.linkToOCS('apps/notifications/api/v1', 2) + 'notifications/' + id + '?format=json',
+				url: OC.generateUrl('apps/notifications/api/v2/notifications/' + id),
 				type: 'DELETE',
 				success: function(data) {
 					self._removeNotification(id);
@@ -127,7 +141,8 @@
 			delete OCA.Notifications.notifications[id];
 
 			$notification.remove();
-			if (_.keys(OCA.Notifications.notifications).length === 0) {
+			if (_.keys(OCA.Notifications.notifications).length === 0 &&
+					this.$container.find('div.notification-controls').length === 0) {
 				this._onHaveNoNotifications();
 			}
 		},
@@ -140,65 +155,163 @@
 			OC.showMenu(null, OCA.Notifications.$container);
 		},
 
-		initialFetch: function() {
-			var self = this;
+		/**
+		 * Restart the polling. Use "clearInterval(this.interval)" to stop the polling
+		 */
+		restartPolling: function() {
+			this.interval = setInterval(_.bind(this.pollingV2, this), this.pollInterval);
+		},
 
-			this.fetch(
-				function(data) {
+		/**
+		 * Make a GET request to the target url. Consider the result of the request as a list of
+		 * notifications sorted from newer to older and draw those notifications accordingly in the UI.
+		 * @param {string} url the url of the request, it should be apps/notifications/api/v2/notifications?fetch=desc
+		 * with additional parameters in the url
+		 * @param {function} successCallback the callback that will be executed if the call is
+		 * successful after the notification rendering is done.
+		 * @param {function} errorCallback the callback that will be executed if the call fails
+		 */
+		fetchDescendentV2: function(url, successCallback, errorCallback) {
+			var self = this;
+			var request = $.ajax({
+				url: url,
+				type: 'GET'
+			}).done(function(result, textStatus, jqxhr) {
 					// Fill Array
-					$.each(data, function(index) {
-						var n = new self.Notif(data[index]);
+					$.each(result.data, function(index) {
+						var n = new self.Notif(result.data[index]);
 						self.notifications[n.getId()] = n;
-						self.addToUI(n);
+						self.appendToUI(n);
 					});
+					if (typeof result.next !== 'undefined') {
+						self.addShowMoreNotificationsButton(result.next);
+					}
 					// Check if we have any, and notify the UI
 					if (self.numNotifications() !== 0) {
 						self._onHaveNotifications();
 					} else {
 						self._onHaveNoNotifications();
 					}
-				},
+			}).fail(function() {
 				_.bind(self._onFetchError, self)
-			);
+			});
+
+			if (successCallback) {
+				request.done(successCallback);
+			}
+
+			if (errorCallback) {
+				request.fail(errorCallback);
+			}
 		},
 
 		/**
-		 * Background fetch handler
+		 * Make a GET request to the target url. Consider the result of the request as a list of
+		 * notifications sorted from newer to older and draw those notifications accordingly in the UI.
+		 * @param {string} url the url of the request, it should be apps/notifications/api/v2/notifications?fetch=asc
+		 * with additional parameters in the url
+		 * @param {function} successCallback the callback that will be executed if the call is
+		 * successful after the notification rendering is done.
+		 * @param {function} errorCallback the callback that will be executed if the call fails
 		 */
-		backgroundFetch: function() {
+		fetchAscendentV2: function(url, successCallback, errorCallback) {
 			var self = this;
-
-			this.fetch(
-				function(data) {
-					var inJson = [];
-					var oldNum = self.numNotifications();
-					$.each(data, function(index) {
-						var n = new self.Notif(data[index]);
-						inJson.push(n.getId());
-						if (!self.getNotification(n.getId())){
-							// New notification!
-							self._onNewNotification(n);
-						}
+			var request = $.ajax({
+				url: url,
+				type: 'GET'
+			}).done(function(result, textStatus, jqxhr){
+					// Fill Array
+					$.each(result.data, function(index) {
+						var n = new self.Notif(result.data[index]);
+						self.notifications[n.getId()] = n;
+						self.addToUI(n);
 					});
-
-					for (var n in self.getNotifications()) {
-						if (inJson.indexOf(self.getNotifications()[n].getId()) === -1) {
-							// Not in JSON, remove from UI
-							self._onRemoveNotification(self.getNotifications()[n]);
-						}
+					if (typeof result.next !== 'undefined') {
+						self.addShowNewerNotificationsButton(result.next);
 					}
-
-					// Now check if we suddenly have notifs, or now none
-					if (oldNum == 0 && self.numNotifications() !== 0) {
-						// We now have some!
+					// Check if we have any, and notify the UI
+					if (self.numNotifications() !== 0) {
 						self._onHaveNotifications();
-					} else if (oldNum != 0 && self.numNotifications() === 0) {
-						// Now we have none
+					} else {
 						self._onHaveNoNotifications();
 					}
-				},
+			}).fail(function() {
 				_.bind(self._onFetchError, self)
-			);
+			});
+
+			if (successCallback) {
+				request.done(successCallback);
+			}
+
+			if (errorCallback) {
+				request.fail(errorCallback);
+			}
+		},
+
+		/**
+		 * Make a request to the polling endpoint and update the last notification id. If it's properly
+		 * updated the polling will stop
+		 */
+		pollingV2: function() {
+			var self = this;
+			var request = $.ajax({
+				url: OC.generateUrl('apps/notifications/api/v2/tracker/notifications/polling'),
+				type: 'GET'
+			}).done(function(result, textStatus, jqxhr){
+				var lastNotificationId = jqxhr.getResponseHeader('OC-Last-Notification');
+				if (self.updateLastKnowId(lastNotificationId)) {
+					clearInterval(self.interval);
+				}
+			});
+		},
+
+		/**
+		 * Update the last known notification id. If the new id is greater than the old one, make
+		 * the bell icon flicker and show a button to fetch the newer notifications. Also show a
+		 * browser notification if possible.
+		 * @return true if the value is updated, false otherwise
+		 */
+		updateLastKnowId: function(newId) {
+			var previousId = this.lastKnownId;
+			this.lastKnownId = newId;
+			if (previousId !== null && parseInt(previousId, 10) < parseInt(newId, 10)) {
+				this._onHaveNotifications();
+				this._onLastKnownIdChange();
+				this.popupWebBrowserNotification();
+				return true;
+			}
+			return false;
+		},
+
+		/**
+		 * Update the last shown notification id to keep track of what notifications we should request
+		 * later. Only update if the new id is greater than the old one.
+		 * @param {string} newId the newest id shown to the user.
+		 */
+		updateLastShownId: function(newId) {
+			var newIdInt = parseInt(newId, 10);
+			var lastShownId = this.$container.data('lastShownId');
+			if (lastShownId === undefined || newIdInt > lastShownId) {
+				this.$container.data('lastShownId', newIdInt);
+			}
+		},
+
+		/**
+		 * Get the last shown id value stored with the "updateLastShownId" method
+		 * @return {string|undefined} the stored value, or undefined if no value has been stored yet
+		 */
+		getLastShownId: function() {
+			return this.$container.data('lastShownId');
+		},
+
+		_onLastKnownIdChange: function() {
+			var lastShownId = this.$container.find('div.notification-wrapper .notification:first').data('id');
+			if (lastShownId === undefined) {
+				// if we don't know the id shown, rely on the stored one
+				lastShownId = this.getLastShownId();
+			}
+			var targetUrl = OC.generateUrl('apps/notifications/api/v2/notifications?id=' + lastShownId + '&fetch=asc&limit=3');
+			this.addShowNewerNotificationsButton(targetUrl);
 		},
 
 		/**
@@ -215,74 +328,115 @@
 		},
 
 		/**
-		 * Handles removing the Notification from the UI when no longer in JSON
-		 * @param {OCA.Notifications.Notification} notification
+		 * Show a browser notification to notify the user about new notifications
 		 */
-		_onRemoveNotification: function(notification) {
-			$('div.notification[data-id='+escapeHTML(notification.getId())+']').remove();
-			delete OCA.Notifications.notifications[notification.getId()];
-		},
-
-		/**
-		 * Handle new notification received
-		 * @param {OCA.Notifications.Notification} notification
-		 */
-		_onNewNotification: function(notification) {
-			// Add it to the array
-			OCA.Notifications.notifications[notification.getId()] = notification;
-			// Add to the UI
-			OCA.Notifications.addToUI(notification);
-
-			// Trigger browsers web notification
-			// https://github.com/owncloud/notifications/issues/1
-			if ("Notification" in window) {
-				if (Notification.permission === "granted") {
-					// If it's okay let's create a notification
-					OCA.Notifications.createWebNotification(notification);
-				}
-
-				// Otherwise, we need to ask the user for permission
-				else if (Notification.permission !== 'denied') {
-					Notification.requestPermission(function (permission) {
-						// If the user accepts, let's create a notification
-						if (permission === "granted") {
-							OCA.Notifications.createWebNotification(notification);
-						}
-					});
-				}
+		popupWebBrowserNotification: function() {
+			if ('Notification' in window && Notification.permission === 'granted') {
+				var self = this;
+				var title = t('notifications', 'Notifications available on {server}', {server: location.host});
+				var body = t('notifications', 'You have new notifications available. Go and check them!');
+				var notif = new Notification(title, {
+					body: body,
+					lang: OC.getLocale(),
+					requireInteraction: true
+				});
 			}
-		},
-
-		/**
-		 * Create a browser notification
-		 *
-		 * @see https://developer.mozilla.org/en/docs/Web/API/notification
-		 * @param {OCA.Notifications.Notification} notification
-		 */
-		createWebNotification: function (notification) {
-			var n = new Notification(notification.getSubject(), {
-				title: notification.getSubject(),
-				lang: OC.getLocale(),
-				body: notification.getRawMessage(),
-				icon: notification.getIcon(),
-				tag: notification.getId()
-			});
-			setTimeout(n.close.bind(n), 5000);
 		},
 
 		_shutDownNotifications: function() {
 			// The app was disabled or has no notifiers, so we can stop polling
 			// And hide the UI as well
 			window.clearInterval(this.interval);
-			this.$notifications.addClass('hidden');
 		},
 
 		/**
-		 * Adds the notification to the UI
+		 * Prepend the notification in the UI container
 		 * @param {OCA.Notifications.Notification} notification
 		 */
 		addToUI: function(notification) {
-			$('div.notification-wrapper').prepend(notification.renderElement());
+			this.$container.find('div.notification-wrapper').prepend(notification.renderElement());
+			this.updateLastShownId(notification.getId());
+		},
+
+		/**
+		 * Append the notification in the UI container
+		 * @param {OCA.Notifications.Notification} notification
+		 */
+		appendToUI: function(notification) {
+			this.$container.find('div.notification-wrapper').append(notification.renderElement());
+		},
+
+		/**
+		 * Add a button to the end of the notification list to fetch the next bunch of notifications.
+		 * @param {string} nextUrl the url that will be used for a "fetchDescendentV2" call, that
+		 * will be called when the button is clicked. The url should normally be the "next" url
+		 * from a result of a previous "fetchDescendentV2" call.
+		 */
+		addShowMoreNotificationsButton: function(nextUrl) {
+			var self = this;
+			var $notificationControlsDiv = $('<div>', {
+				'class' : 'notification-controls controls-below'
+			});
+
+			var $showMoreButton = $('<button>', {
+				'class' : 'notification-showmore',
+				'text' : t('notifications', 'Show More')
+			});
+
+			$showMoreButton.click(function() {
+				self.removeShowMoreNotificationsButton();
+				self.fetchDescendentV2(nextUrl);
+			});
+
+			$notificationControlsDiv.append($showMoreButton);
+
+			this.$container.find('div.notification-wrapper').append($notificationControlsDiv);
+		},
+
+		/**
+		 * Remove the button created with the "addShowMoreNotificationsButton"
+		 */
+		removeShowMoreNotificationsButton: function() {
+			this.$container.find('div.notification-controls.controls-below').remove();
+		},
+
+		/**
+		 * Add a button to the beginning of the notification list to fetch the newer bunch of
+		 * notifications. Once the user click in the button, polling will be restarted if the
+		 * "fetchAscendentV2" call doesn't return the link to the next call (there aren't any
+		 * additional notification available for now)
+		 * @param {string} nextUrl the url that will be used for a "fetchAscendentV2" call, that
+		 * will be called when the button is clicked. The url should normally be the "next" url
+		 * from a result of a previous "fetchAscendentV2" call.
+		 */
+		addShowNewerNotificationsButton: function(nextUrl) {
+			var self = this;
+			var $notificationControlsDiv = $('<div>', {
+				'class' : 'notification-controls controls-above'
+			});
+			var $showMoreButton = $('<button>', {
+				'class' : 'notification-shownewer',
+				'text' : t('notifications', 'Show Newer Notifications')
+			});
+			$showMoreButton.click(function() {
+				self.removeShowNewerNotificationButton();
+				self.fetchAscendentV2(nextUrl, function(result) {
+					if (typeof result.next === 'undefined') {
+						self.restartPolling();
+					}
+				});
+			});
+
+			$notificationControlsDiv.append($showMoreButton);
+
+			this.$container.find('div.notification-wrapper').prepend($notificationControlsDiv);
+		},
+
+		/**
+		 * Remove the button created by "addShowNewerNotificationsButton"
+		 */
+		removeShowNewerNotificationButton: function() {
+			this.$container.find('div.notification-controls.controls-above').remove();
 		},
 
 		/**
@@ -298,8 +452,6 @@
 				.animate({opacity: 1}, 600)
 				.animate({opacity: 0.7}, 600);
 			this.$container.find('.emptycontent').addClass('hidden');
-
-			this.$notifications.removeClass('hidden');
 		},
 
 		/**
@@ -310,32 +462,6 @@
 			$('div.notifications-button').removeClass('hasNotifications');
 			$('div.notifications .emptycontent').removeClass('hidden');
 			this.$button.find('img').attr('src', OC.imagePath('notifications', 'notifications'));
-
-			this.$notifications.addClass('hidden');
-		},
-
-		/**
-		 * Performs the AJAX request to retrieve the notifications
-		 * @param {Function} success
-		 * @param {Function} failure
-		 */
-		fetch: function(success, failure){
-			var self = this;
-			var request = $.ajax({
-				url: OC.linkToOCS('apps/notifications/api/v1', 2) + 'notifications?format=json',
-				type: 'GET'
-			});
-
-
-			request.done(function(data, statusText, xhr) {
-				if (xhr.status === 204 || data.ocs.meta.statuscode === 204) {
-					// 204 No Content - Intercept when no notifiers are there.
-					self._shutDownNotifications();
-				} else {
-					success(data.ocs.data, statusText, xhr);
-				}
-			});
-			request.fail(failure);
 		},
 
 		/**
@@ -355,14 +481,6 @@
 		 */
 		getNotifications: function() {
 			return this.notifications;
-		},
-
-		/**
-		 * Handles the returned data from the AJAX call
-		 * @param {object} responseData
-		 */
-		parseNotifications: function(responseData) {
-
 		},
 
 		/**

--- a/lib/Controller/EndpointV2Controller.php
+++ b/lib/Controller/EndpointV2Controller.php
@@ -88,6 +88,9 @@ class EndpointV2Controller extends Controller {
 
 		// fetch the max id before getting the list of notifications
 		$maxId = $this->handler->getMaxNotificationId($userid);
+		if ($maxId === null) {
+			$maxId = -1;
+		}
 
 		if ($order === 'ASC') {
 			// try to get an additional result to check if there is more results available or not
@@ -194,6 +197,9 @@ class EndpointV2Controller extends Controller {
 
 
 		$maxId = $this->handler->getMaxNotificationId($userid);
+		if ($maxId === null) {
+			$maxId = -1;
+		}
 
 		$jsonResponse = new JSONResponse([
 			'id' => $maxId,

--- a/lib/Controller/EndpointV2Controller.php
+++ b/lib/Controller/EndpointV2Controller.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Notifications\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\IURLGenerator;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Notification\IAction;
+use OCA\Notifications\Handler;
+
+class EndpointV2Controller extends Controller {
+	/** lists will return a maximum number of 20 results */
+	const ENFORCED_LIST_LIMIT = 20;
+
+	/** @var Handler */
+	private $handler;
+
+	/** @var IManager */
+	private $manager;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(Handler $handler, IManager $manager, IUserSession $userSession, IConfig $config, IURLGenerator $urlGenerator, IRequest $request) {
+		parent::__construct('notifications', $request);
+		$this->handler = $handler;
+		$this->manager = $manager;
+		$this->userSession = $userSession;
+		$this->config = $config;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param int $id the id of the notification
+	 * @param string $fetch the fetch order
+	 * @param int $limit the limit for the number of notifications to be returned
+	 */
+	public function listNotifications($id = null, $fetch = 'desc', $limit = self::ENFORCED_LIST_LIMIT) {
+		$userObject = $this->userSession->getUser();
+		if ($userObject === null) {
+			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+		}
+		$userid = $userObject->getUID();
+
+		// if it's "asc" keep it, if not consider it "desc"
+		if (strtoupper($fetch) !== 'ASC') {
+			$order = 'DESC';
+		} else {
+			$order = 'ASC';
+		}
+
+		$maxResults = min(self::ENFORCED_LIST_LIMIT, $limit);
+
+		$language = $this->config->getUserValue($userid, 'core', 'lang', null);
+
+		// fetch the max id before getting the list of notifications
+		$maxId = $this->handler->getMaxNotificationId($userid);
+
+		if ($order === 'ASC') {
+			// try to get an additional result to check if there is more results available or not
+			$notifications = $this->handler->fetchAscendentList($userid, $id, $maxResults + 1, function (INotification $rawNotification) use ($language) {
+				// we need to prepare the notification in order to decide to discard it or not.
+				// we'll return the prepared notification or null in case of exceptions.
+				return $this->prepareNotification($rawNotification, $language);
+			});
+		} else {
+			$notifications = $this->handler->fetchDescendentList($userid, $id, $maxResults + 1, function (INotification $rawNotification) use ($language) {
+				return $this->prepareNotification($rawNotification, $language);
+			});
+		}
+
+		$data = [];
+		foreach ($notifications as $notificationId => $notification) {
+			$data[] = $this->notificationToArray($notificationId, $notification);
+		}
+
+		if (count($data) > $maxResults) {
+			// make sure we return the number of results specified
+			$data = array_slice($data, 0, $maxResults, true);
+
+			$url = $this->urlGenerator->linkToRoute('notifications.EndpointV2.listNotifications', [
+				'id' => $data[count($data) - 1]['notification_id'],
+				'fetch' => strtolower($order),
+				'limit' => $maxResults,
+			]);
+
+			$jsonResponse = new JSONResponse([
+				'data' => $data,
+				'next' => $url,
+			]);
+		} else {
+			$jsonResponse = new JSONResponse([
+				'data' => $data,
+			]);
+		}
+		$jsonResponse->addHeader('OC-Last-Notification', $maxId);
+		return $jsonResponse;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param int $id
+	 * @return Result
+	 */
+	public function getNotification($id) {
+		$userObject = $this->userSession->getUser();
+		if ($userObject === null) {
+			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+		}
+		$userid = $userObject->getUID();
+
+		$notification = $this->handler->getById($id, $userid);
+
+		if (!($notification instanceof INotification)) {
+			return new JSONResponse(null, HTTP::STATUS_NOT_FOUND);
+		}
+
+		$language = $this->config->getUserValue($userid, 'core', 'lang', null);
+
+		try {
+			$notification = $this->manager->prepare($notification, $language);
+		} catch (\InvalidArgumentException $e) {
+			// The app was disabled
+			return new JSONResponse(null, HTTP::STATUS_NOT_FOUND);
+		}
+
+		return new JSONResponse($this->notificationToArray($id, $notification));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param int $id
+	 * @return Result
+	 */
+	public function deleteNotification($id) {
+		$userObject = $this->userSession->getUser();
+		if ($userObject === null) {
+			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+		}
+		$userid = $userObject->getUID();
+
+		$this->handler->deleteById($id, $userid);
+		return new JSONResponse();
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function getLastNotificationId() {
+		$userObject = $this->userSession->getUser();
+		if ($userObject === null) {
+			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+		}
+		$userid = $userObject->getUID();
+
+
+		$maxId = $this->handler->getMaxNotificationId($userid);
+
+		$jsonResponse = new JSONResponse([
+			'id' => $maxId,
+		]);
+		$jsonResponse->addHeader('OC-Last-Notification', $maxId);
+		return $jsonResponse;
+	}
+
+	/**
+	 * @param int $notificationId
+	 * @param INotification $notification
+	 * @return array
+	 */
+	protected function notificationToArray($notificationId, INotification $notification) {
+		$data = [
+			'notification_id' => $notificationId,
+			'app' => $notification->getApp(),
+			'user' => $notification->getUser(),
+			'datetime' => $notification->getDateTime()->format('c'),
+			'object_type' => $notification->getObjectType(),
+			'object_id' => $notification->getObjectId(),
+			'subject' => $notification->getParsedSubject(),
+			'message' => $notification->getParsedMessage(),
+			'link' => $notification->getLink(),
+			'actions' => [],
+		];
+		if (method_exists($notification, 'getIcon')) {
+			$data['icon'] = $notification->getIcon();
+		}
+
+		foreach ($notification->getParsedActions() as $action) {
+			$data['actions'][] = $this->actionToArray($action);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @param IAction $action
+	 * @return array
+	 */
+	protected function actionToArray(IAction $action) {
+		return [
+			'label' => $action->getParsedLabel(),
+			'link' => $action->getLink(),
+			'type' => $action->getRequestType(),
+			'primary' => $action->isPrimary(),
+		];
+	}
+
+	/**
+	 * @internal
+	 * Prepare a notification. This should only be used internally as part of a callback in this
+	 * class. Use IManager::prepare to prepare the notification.
+	 * @param INotification $notification the notification to be prepared
+	 * @param string $language the language to be used
+	 * @return INotification|null the prepared notification or null if it couldn't be prepared
+	 */
+	public function prepareNotification(INotification $notification, $language) {
+		try {
+			return $this->manager->prepare($notification, $language);
+		} catch (\InvalidArgumentException $e) {
+			// The app was disabled, skip the notification
+			return null;
+		}
+	}
+}

--- a/lib/Controller/EndpointV2Controller.php
+++ b/lib/Controller/EndpointV2Controller.php
@@ -72,7 +72,9 @@ class EndpointV2Controller extends Controller {
 	public function listNotifications($id = null, $fetch = 'desc', $limit = self::ENFORCED_LIST_LIMIT, $format = 'json') {
 		$userObject = $this->userSession->getUser();
 		if ($userObject === null) {
-			return new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_FORBIDDEN);
+			return $ocsResponse;
 		}
 		$userid = $userObject->getUID();
 
@@ -146,14 +148,18 @@ class EndpointV2Controller extends Controller {
 	public function getNotification($id, $format = 'json') {
 		$userObject = $this->userSession->getUser();
 		if ($userObject === null) {
-			return new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_FORBIDDEN);
+			return $ocsResponse;
 		}
 		$userid = $userObject->getUID();
 
 		$notification = $this->handler->getById($id, $userid);
 
 		if (!($notification instanceof INotification)) {
-			return new OCSResponse($format, Http::STATUS_NOT_FOUND, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_NOT_FOUND, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_NOT_FOUND);
+			return $ocsResponse;
 		}
 
 		$language = $this->config->getUserValue($userid, 'core', 'lang', null);
@@ -162,11 +168,13 @@ class EndpointV2Controller extends Controller {
 			$notification = $this->manager->prepare($notification, $language);
 		} catch (\InvalidArgumentException $e) {
 			// The app was disabled
-			return new OCSResponse($format, Http::STATUS_NOT_FOUND, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_NOT_FOUND, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_NOT_FOUND);
+			return $ocsResponse;
 		}
 
 		return new OCSResponse($format, Http::STATUS_OK, null,
-			$this->notificationToArray($id, $notificationToArray), null, null, true);
+			$this->notificationToArray($id, $notification), null, null, true);
 	}
 
 	/**
@@ -180,7 +188,9 @@ class EndpointV2Controller extends Controller {
 	public function deleteNotification($id, $format = 'json') {
 		$userObject = $this->userSession->getUser();
 		if ($userObject === null) {
-			return new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_FORBIDDEN);
+			return $ocsResponse;
 		}
 		$userid = $userObject->getUID();
 
@@ -198,7 +208,9 @@ class EndpointV2Controller extends Controller {
 	public function getLastNotificationId($format = 'json') {
 		$userObject = $this->userSession->getUser();
 		if ($userObject === null) {
-			return new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse = new OCSResponse($format, Http::STATUS_FORBIDDEN, null, [], null, null, true);
+			$ocsResponse->setStatus(Http::STATUS_FORBIDDEN);
+			return $ocsResponse;
 		}
 		$userid = $userObject->getUID();
 

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -29,6 +29,12 @@ use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 
 class Handler {
+	/**
+	 * Used in fetchDescendentList and fetchAscendentList method to limit the number of results
+	 * Intended to be used as default value, but a larger value can be set (no enforcement)
+	 */
+	const FETCH_DEFAULT_LIMIT = 20;
+
 	/** @var IDBConnection */
 	protected $connection;
 
@@ -157,6 +163,118 @@ class Handler {
 		$statement->closeCursor();
 
 		return $notifications;
+	}
+
+	/**
+	 * Fetch a list of notifications starting from notification id $id up to $limit number of
+	 * notifications. If id = null, we'll start from the newest id available. If there is a
+	 * notification matching the id, it will be ignored and won't be returned
+	 * @param string $user the target user for the notifications
+	 * @param int|null $id the starting notification id (it won't be returned)
+	 * @param int $limit the maximum number of notifications that will be fetched
+	 * @param callable|null $callable the condition that the notification should match to be part
+	 * of the result. The callable will be called with a INotification object as parameter such as
+	 * "$callable(INotification $notification)" and must return an INotification object if such
+	 * notification should be part of the result or null otherwise
+	 * @return array [notification_id => INotification]
+	 */
+	public function fetchDescendentList($user, $id = null, $limit = self::FETCH_DEFAULT_LIMIT, $callable = null) {
+		$sql = $this->connection->getQueryBuilder();
+		$sql->select('*')
+			->from('notifications')
+			->orderBy('notification_id', 'DESC');
+
+		$sql->where($sql->expr()->eq('user', $sql->createNamedParameter($user)));
+		if ($id !== null) {
+			$sql->andWhere($sql->expr()->lt('notification_id', $sql->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		}
+
+		$statement = $sql->execute();
+
+		$notifications = [];
+		$numberOfNotifications = 0;
+		while (($row = $statement->fetch()) && $numberOfNotifications < $limit) {
+			$notification = $this->notificationFromRow($row);
+			$processedNotification = $this->processByCallback($notification, $callable);
+			if ($processedNotification !== null) {
+				$notifications[(int) $row['notification_id']] = $processedNotification;
+				$numberOfNotifications++;
+			}
+		}
+		$statement->closeCursor();
+
+		return $notifications;
+	}
+
+	/**
+	 * Fetch a list of notifications starting from notification id $id up to $limit number of
+	 * notifications. If id = null, we'll start from the oldest id available. If there is a
+	 * notification matching the id, it will be ignored and won't be returned
+	 * @param string $user the target user for the notifications
+	 * @param int|null $id the starting notification id (it won't be returned)
+	 * @param int $limit the maximum number of notifications that will be fetched
+	 * @param callable|null $callable the condition that the notification should match to be part
+	 * of the result. The callable will be called with a INotification object as parameter such as
+	 * "$callable(INotification $notification)" and must return an INotification object if such
+	 * notification should be part of the result or null otherwise
+	 * @return array [notification_id => INotification]
+	 */
+	public function fetchAscendentList($user, $id = null, $limit = self::FETCH_DEFAULT_LIMIT, $callable = null) {
+		$sql = $this->connection->getQueryBuilder();
+		$sql->select('*')
+			->from('notifications')
+			->orderBy('notification_id', 'ASC');
+
+		$sql->where($sql->expr()->eq('user', $sql->createNamedParameter($user)));
+		if ($id !== null) {
+			$sql->andWhere($sql->expr()->gt('notification_id', $sql->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		}
+
+		$statement = $sql->execute();
+
+		$notifications = [];
+		$numberOfNotifications = 0;
+		while (($row = $statement->fetch()) && $numberOfNotifications < $limit) {
+			$notification = $this->notificationFromRow($row);
+			$processedNotification = $this->processByCallback($notification, $callable);
+			if ($processedNotification !== null) {
+				$notifications[(int) $row['notification_id']] = $processedNotification;
+				$numberOfNotifications++;
+			}
+		}
+		$statement->closeCursor();
+
+		return $notifications;
+	}
+
+	/**
+	 * Get the maximum notification id available for the user
+	 * @param string $user the user to be filtered with
+	 * @return int|null the maximum notification id for the user or null if the user doesn't have
+	 * any notification
+	 */
+	public function getMaxNotificationId($user) {
+		$sql = $this->connection->getQueryBuilder();
+		$sql->select($sql->createFunction('max(notification_id) as `max_id`'))
+			->from('notifications')
+			->where($sql->expr()->eq('user', $sql->createNamedParameter($user)));
+
+		$statement = $sql->execute();
+		$row = $statement->fetch();
+		$maxId = $row['max_id'];
+		$statement->closeCursor();
+
+		return $maxId;
+	}
+
+	private function processByCallback(INotification $notification, $callable = null) {
+		if ($callable === null) {
+			return $notification;
+		} else {
+			if (is_callable($callable)) {
+				return $callable($notification);
+			}
+		}
 	}
 
 	/**

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -255,7 +255,7 @@ class Handler {
 	 */
 	public function getMaxNotificationId($user) {
 		$sql = $this->connection->getQueryBuilder();
-		$sql->select($sql->createFunction('max(notification_id) as `max_id`'))
+		$sql->select($sql->createFunction('max(`notification_id`) as `max_id`'))
 			->from('notifications')
 			->where($sql->expr()->eq('user', $sql->createNamedParameter($user)));
 

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -268,12 +268,10 @@ class Handler {
 	}
 
 	private function processByCallback(INotification $notification, $callable = null) {
-		if ($callable === null) {
-			return $notification;
+		if (is_callable($callable)) {
+			return $callable($notification);
 		} else {
-			if (is_callable($callable)) {
-				return $callable($notification);
-			}
+			return $notification;
 		}
 	}
 

--- a/tests/Unit/Controller/EndpointV2ControllerTest.php
+++ b/tests/Unit/Controller/EndpointV2ControllerTest.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Notifications\Tests\Unit\Controller;
+
+use OCP\AppFramework\Http;
+use OCP\IUser;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\IURLGenerator;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Notification\IAction;
+use OCA\Notifications\Handler;
+use OCA\Notifications\Controller\EndpointV2Controller;
+
+class EndpointV2ControllerTest extends \Test\TestCase {
+	/** @var Handler */
+	private $handler;
+
+	/** @var IManager */
+	private $manager;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var EndpointV2Controller */
+	private $controller;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMockBuilder(IRequest::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->handler = $this->getMockBuilder(Handler::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->manager = $this->getMockBuilder(IManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->controller = new EndpointV2Controller($this->handler, $this->manager, $this->userSession, $this->config, $this->urlGenerator, $this->request);
+	}
+
+	private function getNotificationList() {
+		$result = [];
+		for ($i = 5; $i <= 40; $i++) {
+			$notification = $this->getMockBuilder(INotification::class)
+				->disableOriginalConstructor()
+				->getMock();
+			$notification->method('getObjectType')
+				->willReturn('test_notification');
+			$notification->method('getObjectId')
+				->willReturn(strval($i));
+			$notification->method('getDateTime')
+				->willReturn(new \DateTime());
+			$notification->method('getParsedActions')
+				->willReturn([]);
+			$result[$i] = $notification;
+		}
+		return $result;
+	}
+
+	private function isKeySortedBottomToTop(array $arr) {
+		$previousId = null;
+		foreach ($arr as $key => $value) {
+			if ($previousId !== null) {
+				if ($previousId > $value['notification_id']) {
+					return false;
+				}
+			}
+			$previousId = $value['notification_id'];
+		}
+		return true;
+	}
+
+	private function isKeySortedTopToBottom(array $arr) {
+		$previousId = null;
+		foreach ($arr as $key => $value) {
+			if ($previousId !== null) {
+				if ($previousId < $value['notification_id']) {
+					return false;
+				}
+			}
+			$previousId = $value['notification_id'];
+		}
+		return true;
+	}
+
+	public function testListNotificationsWrongUser() {
+		$this->userSession->method('getUser')
+			->willReturn(null);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $this->controller->listNotifications()->getStatus());
+	}
+
+	/**
+	 * the id is forwarded directly to the handler, so need to test with different ids
+	 */
+	public function testListNotificationsDescendent() {
+		$maxResults = EndpointV2Controller::ENFORCED_LIST_LIMIT;
+		$notificationList = $this->getNotificationList();
+		krsort($notificationList);
+		$notificationList = array_slice($notificationList, 0, $maxResults + 1, true);
+
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->handler->method('getMaxNotificationId')
+			->willReturn(123);  // purposely use a different max id than the one returned in the list
+		$this->handler->method('fetchDescendentList')
+			->with('test_user1', null, $maxResults + 1, $this->anything())
+			->willReturn($notificationList);
+
+		$this->manager->method('prepare')
+			->willReturn($this->returnArgument(0));
+
+		$this->urlGenerator->method('linkToRoute')
+			->willReturn('http://server/owncloud/route?id=20&fetch=desc&limit=20');
+		// we won't check the url returned by the urlGenerator, any path will do
+
+		$jsonResult = $this->controller->listNotifications();
+		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+
+		$rawData = $jsonResult->getData();
+		$this->assertEquals($maxResults, count($rawData['data']));
+		$this->assertTrue($this->isKeySortedTopToBottom($rawData['data']));
+		$this->assertArrayHasKey('next', $rawData);
+		$this->assertEquals('http://server/owncloud/route?id=20&fetch=desc&limit=20', $rawData['next']);
+
+		$resultHeaders = $jsonResult->getHeaders();
+		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
+		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
+	}
+
+	/**
+	 * the id is forwarded directly to the handler, so need to test with different ids
+	 */
+	public function testListNotificationsAscendent() {
+		$maxResults = EndpointV2Controller::ENFORCED_LIST_LIMIT;
+		$notificationList = $this->getNotificationList();
+		$notificationList = array_slice($notificationList, 0, $maxResults + 1, true);
+
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->handler->method('getMaxNotificationId')
+			->willReturn(123);  // purposely use a different max id than the one returned in the list
+		$this->handler->method('fetchAscendentList')
+			->with('test_user1', null, $maxResults + 1, $this->anything())
+			->willReturn($notificationList);
+
+		$this->manager->method('prepare')
+			->willReturn($this->returnArgument(0));
+
+		$this->urlGenerator->method('linkToRoute')
+			->willReturn('http://server/owncloud/route?id=20&fetch=asc&limit=20');
+		// we won't check the url returned by the urlGenerator, any path will do
+
+		$jsonResult = $this->controller->listNotifications(null, 'asc');
+		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+
+		$rawData = $jsonResult->getData();
+		$this->assertEquals($maxResults, count($rawData['data']));
+		$this->assertTrue($this->isKeySortedBottomToTop($rawData['data']));
+		$this->assertArrayHasKey('next', $rawData);
+		$this->assertEquals('http://server/owncloud/route?id=20&fetch=asc&limit=20', $rawData['next']);
+
+		$resultHeaders = $jsonResult->getHeaders();
+		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
+		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
+	}
+
+	public function testListNotificationsDescendentNoMoreResults() {
+		$maxResults = EndpointV2Controller::ENFORCED_LIST_LIMIT;
+		$notificationList = $this->getNotificationList();
+		krsort($notificationList);
+		$notificationList = array_slice($notificationList, 0, $maxResults + 1, true);
+
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->handler->method('getMaxNotificationId')
+			->willReturn(123);  // purposely use a different max id than the one returned in the list
+		$this->handler->method('fetchDescendentList')
+			->with('test_user1', null, $maxResults + 1, $this->anything())
+			->willReturn(array_slice($notificationList, 0, 3, true));
+
+		$this->manager->method('prepare')
+			->willReturn($this->returnArgument(0));
+
+		$jsonResult = $this->controller->listNotifications();
+		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+
+		$rawData = $jsonResult->getData();
+		$this->assertLessThan($maxResults, count($rawData['data']));
+		$this->assertTrue($this->isKeySortedTopToBottom($rawData['data']));
+		$this->assertArrayNotHasKey('next', $rawData);
+
+		$resultHeaders = $jsonResult->getHeaders();
+		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
+		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
+	}
+
+	public function testGetNotificationWrongUser() {
+		$this->userSession->method('getUser')
+			->willReturn(null);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $this->controller->getNotification(5)->getStatus());
+	}
+
+	public function testGetNotificationNotNotificationType() {
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->handler->method('getById')
+			->willReturn(false);
+
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->controller->getNotification(5)->getStatus());
+	}
+
+	public function testGetNotificationCannotPrepare() {
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$notification = $this->getMockBuilder(INotification::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$notification->method('getObjectType')
+			->willReturn('test_notification');
+		$notification->method('getObjectId')
+			->willReturn('21');
+		$notification->method('getDateTime')
+			->willReturn(new \DateTime());
+		$notification->method('getParsedActions')
+			->willReturn([]);
+
+		$this->handler->method('getById')
+			->willReturn($notification);
+
+		$this->manager->method('prepare')
+			->will($this->throwException(new \InvalidArgumentException()));
+
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->controller->getNotification(5)->getStatus());
+	}
+
+	public function testGetNotification() {
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$datetime = new \DateTime();
+		$notification = $this->getMockBuilder(INotification::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$notification->method('getObjectType')
+			->willReturn('test_notification');
+		$notification->method('getObjectId')
+			->willReturn('21');
+		$notification->method('getDateTime')
+			->willReturn($datetime);
+		$notification->method('getParsedSubject')
+			->willReturn('the parsed subject');
+		$notification->method('getParsedActions')
+			->willReturn([]);
+
+		$this->handler->method('getById')
+			->willReturn($notification);
+
+		$this->manager->method('prepare')
+			->willReturn($notification);
+
+		$jsonResponse = $this->controller->getNotification(5);
+		$this->assertEquals(Http::STATUS_OK, $jsonResponse->getStatus());
+
+		$rawData = $jsonResponse->getData();
+		$this->assertEquals('5', $rawData['notification_id']);
+		$this->assertEquals($datetime->format('c'), $rawData['datetime']);
+		$this->assertEquals('the parsed subject', $rawData['subject']);
+		$this->assertEquals([], $rawData['actions']);
+	}
+
+	public function testDeleteNotificationWrongUser() {
+		$this->userSession->method('getUser')
+			->willReturn(null);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $this->controller->deleteNotification(5)->getStatus());
+	}
+
+	public function testDeleteNotification() {
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->assertEquals(Http::STATUS_OK, $this->controller->deleteNotification(5)->getStatus());
+	}
+
+	public function testGetLastNotificationIdWrongUser() {
+		$this->userSession->method('getUser')
+			->willReturn(null);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $this->controller->getLastNotificationId(5)->getStatus());
+	}
+
+	public function testGetLastNotification() {
+		$user = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$user->method('getUID')
+			->willReturn('test_user1');
+		$this->userSession->method('getUser')
+			->willReturn($user);
+
+		$this->handler->method('getMaxNotificationId')
+			->willReturn(321);
+
+		$jsonResponse = $this->controller->getLastNotificationId();
+		$this->assertEquals(Http::STATUS_OK, $jsonResponse->getStatus());
+
+		$rawData = $jsonResponse->getData();
+		$this->assertEquals(['id' => 321], $rawData);
+
+		$resultHeaders = $jsonResponse->getHeaders();
+		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
+		$this->assertEquals(321, $resultHeaders['OC-Last-Notification']);
+	}
+}

--- a/tests/Unit/Controller/EndpointV2ControllerTest.php
+++ b/tests/Unit/Controller/EndpointV2ControllerTest.php
@@ -159,16 +159,17 @@ class EndpointV2ControllerTest extends \Test\TestCase {
 			->willReturn('http://server/owncloud/route?id=20&fetch=desc&limit=20');
 		// we won't check the url returned by the urlGenerator, any path will do
 
-		$jsonResult = $this->controller->listNotifications();
-		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+		$ocsResult = $this->controller->listNotifications();
+		$this->assertEquals(Http::STATUS_OK, $ocsResult->getStatus());
 
-		$rawData = $jsonResult->getData();
-		$this->assertEquals($maxResults, count($rawData['data']));
-		$this->assertTrue($this->isKeySortedTopToBottom($rawData['data']));
+		$rawData = json_decode($ocsResult->render(), true);
+		$rawData = $rawData['ocs']['data'];
+		$this->assertEquals($maxResults, count($rawData['notifications']));
+		$this->assertTrue($this->isKeySortedTopToBottom($rawData['notifications']));
 		$this->assertArrayHasKey('next', $rawData);
 		$this->assertEquals('http://server/owncloud/route?id=20&fetch=desc&limit=20', $rawData['next']);
 
-		$resultHeaders = $jsonResult->getHeaders();
+		$resultHeaders = $ocsResult->getHeaders();
 		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
 		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
 	}
@@ -202,16 +203,17 @@ class EndpointV2ControllerTest extends \Test\TestCase {
 			->willReturn('http://server/owncloud/route?id=20&fetch=asc&limit=20');
 		// we won't check the url returned by the urlGenerator, any path will do
 
-		$jsonResult = $this->controller->listNotifications(null, 'asc');
-		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+		$ocsResult = $this->controller->listNotifications(null, 'asc');
+		$this->assertEquals(Http::STATUS_OK, $ocsResult->getStatus());
 
-		$rawData = $jsonResult->getData();
-		$this->assertEquals($maxResults, count($rawData['data']));
-		$this->assertTrue($this->isKeySortedBottomToTop($rawData['data']));
+		$rawData = json_decode($ocsResult->render(), true);
+		$rawData = $rawData['ocs']['data'];
+		$this->assertEquals($maxResults, count($rawData['notifications']));
+		$this->assertTrue($this->isKeySortedBottomToTop($rawData['notifications']));
 		$this->assertArrayHasKey('next', $rawData);
 		$this->assertEquals('http://server/owncloud/route?id=20&fetch=asc&limit=20', $rawData['next']);
 
-		$resultHeaders = $jsonResult->getHeaders();
+		$resultHeaders = $ocsResult->getHeaders();
 		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
 		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
 	}
@@ -239,15 +241,16 @@ class EndpointV2ControllerTest extends \Test\TestCase {
 		$this->manager->method('prepare')
 			->willReturn($this->returnArgument(0));
 
-		$jsonResult = $this->controller->listNotifications();
-		$this->assertEquals(Http::STATUS_OK, $jsonResult->getStatus());
+		$ocsResult = $this->controller->listNotifications();
+		$this->assertEquals(Http::STATUS_OK, $ocsResult->getStatus());
 
-		$rawData = $jsonResult->getData();
-		$this->assertLessThan($maxResults, count($rawData['data']));
-		$this->assertTrue($this->isKeySortedTopToBottom($rawData['data']));
+		$rawData = json_decode($ocsResult->render(), true);
+		$rawData = $rawData['ocs']['data'];
+		$this->assertLessThan($maxResults, count($rawData['notifications']));
+		$this->assertTrue($this->isKeySortedTopToBottom($rawData['notifications']));
 		$this->assertArrayNotHasKey('next', $rawData);
 
-		$resultHeaders = $jsonResult->getHeaders();
+		$resultHeaders = $ocsResult->getHeaders();
 		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
 		$this->assertEquals(123, $resultHeaders['OC-Last-Notification']);
 	}
@@ -334,10 +337,11 @@ class EndpointV2ControllerTest extends \Test\TestCase {
 		$this->manager->method('prepare')
 			->willReturn($notification);
 
-		$jsonResponse = $this->controller->getNotification(5);
-		$this->assertEquals(Http::STATUS_OK, $jsonResponse->getStatus());
+		$ocsResult = $this->controller->getNotification(5);
+		$this->assertEquals(Http::STATUS_OK, $ocsResult->getStatus());
 
-		$rawData = $jsonResponse->getData();
+		$rawData = json_decode($ocsResult->render(), true);
+		$rawData = $rawData['ocs']['data'];
 		$this->assertEquals('5', $rawData['notification_id']);
 		$this->assertEquals($datetime->format('c'), $rawData['datetime']);
 		$this->assertEquals('the parsed subject', $rawData['subject']);
@@ -382,13 +386,14 @@ class EndpointV2ControllerTest extends \Test\TestCase {
 		$this->handler->method('getMaxNotificationId')
 			->willReturn(321);
 
-		$jsonResponse = $this->controller->getLastNotificationId();
-		$this->assertEquals(Http::STATUS_OK, $jsonResponse->getStatus());
+		$ocsResult = $this->controller->getLastNotificationId();
+		$this->assertEquals(Http::STATUS_OK, $ocsResult->getStatus());
 
-		$rawData = $jsonResponse->getData();
+		$rawData = json_decode($ocsResult->render(), true);
+		$rawData = $rawData['ocs']['data'];
 		$this->assertEquals(['id' => 321], $rawData);
 
-		$resultHeaders = $jsonResponse->getHeaders();
+		$resultHeaders = $ocsResult->getHeaders();
 		$this->assertArrayHasKey('OC-Last-Notification', $resultHeaders);
 		$this->assertEquals(321, $resultHeaders['OC-Last-Notification']);
 	}

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -442,6 +442,92 @@ class HandlerTest extends TestCase {
 		$this->handler->delete($notification4);
 	}
 
+	public function testGetMaxNotificationIdNoNotifications() {
+		$user = uniqid('test_user_');  // any non-existing user is good
+		$this->assertNull($this->handler->getMaxNotificationId($user));
+	}
+
+	public function testGetMaxNotificationId() {
+		$notification1 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'notification',
+			'getObjectId' => '1337',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification3 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'blondification',
+			'getObjectId' => '1339',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification4 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'nonefination',
+			'getObjectId' => '1340',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$this->handler->add($notification1);
+		$this->handler->add($notification3);
+		$this->handler->add($notification4);
+
+		$maxId = $this->handler->getMaxNotificationId('test_user1');
+
+		$limitedNotification = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+		]);
+		$notificationList = $this->handler->get($limitedNotification);
+		$expectedMaxId = -1;
+		foreach ($notificationList as $key => $value) {
+			if ($key > $expectedMaxId) {
+				$expectedMaxId = $key;
+			}
+		}
+		$this->assertEquals($expectedMaxId, $maxId);
+	}
+
 	/**
 	 * @param array $values
 	 * @return \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -22,8 +22,8 @@
 
 namespace OCA\Notifications\Tests\Unit;
 
-
 use OCA\Notifications\Handler;
+use OCP\Notification\INotification;
 
 /**
  * Class HandlerTest
@@ -161,11 +161,285 @@ class HandlerTest extends TestCase {
 
 		// Get with correct user
 		$getNotification = $this->handler->getById($notificationId, 'test_user1');
-		$this->assertInstanceOf('OCP\Notification\INotification', $getNotification);
+		$this->assertInstanceOf(INotification::class, $getNotification);
 
 		// Delete and count
 		$this->handler->deleteById($notificationId, 'test_user1');
 		$this->assertSame(0, $this->handler->count($limitedNotification), 'Wrong notification count for user1 after deleting');
+	}
+
+	public function testFetchDescendentList() {
+		$notification1 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'notification',
+			'getObjectId' => '1337',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification2 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user2',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'notifi-cat-ion',
+			'getObjectId' => '1338',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification3 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'blondification',
+			'getObjectId' => '1339',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification4 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'nonefination',
+			'getObjectId' => '1340',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$this->handler->add($notification1);
+		$this->handler->add($notification2);
+		$this->handler->add($notification3);
+		$this->handler->add($notification4);
+
+		// fetch all the notifications (up to 20)
+		$list = $this->handler->fetchDescendentList('test_user1');
+		$listKeys = array_keys($list);
+		$this->assertEquals(3, count($list));
+		$this->assertEquals('nonefination', $list[$listKeys[0]]->getObjectType());
+		$this->assertEquals('blondification', $list[$listKeys[1]]->getObjectType());
+		$this->assertEquals('notification', $list[$listKeys[2]]->getObjectType());
+		$this->assertTrue($listKeys[0] > $listKeys[1]);
+		$this->assertTrue($listKeys[1] > $listKeys[2]);
+
+		$list2 = $this->handler->fetchDescendentList('test_user1', $listKeys[1]);
+		$listKeys2 = array_keys($list2);
+		$this->assertEquals(1, count($list2));  // only 1 since the id specified won't be included
+		$this->assertEquals('notification', $list[$listKeys2[0]]->getObjectType());
+		$this->assertEquals($listKeys[2], $listKeys2[0]);  // check the id of the notification
+
+		$list3 = $this->handler->fetchDescendentList('test_user1', null, 1);
+		$listKeys3 = array_keys($list3);
+		$this->assertEquals(1, count($list3));  // only 1 since the id specified won't be included
+		$this->assertEquals('nonefination', $list[$listKeys3[0]]->getObjectType());
+		$this->assertEquals($listKeys[0], $listKeys3[0]);  // check the id of the notification
+
+		$list4 = $this->handler->fetchDescendentList('test_user1', $listKeys[0], 1);
+		$listKeys4 = array_keys($list4);
+		$this->assertEquals(1, count($list4));  // only 1 since the id specified won't be included
+		$this->assertEquals('blondification', $list[$listKeys4[0]]->getObjectType());
+		$this->assertEquals($listKeys[1], $listKeys4[0]);  // check the id of the notification
+
+		$callableFunc = function(INotification $notification) {
+			if (strpos($notification->getObjectType(), 'no') === 0) {
+				return $notification;
+			} else {
+				return null;
+			}
+		};
+
+		$list5 = $this->handler->fetchDescendentList('test_user1', null, 20, $callableFunc);
+		$listKeys5 = array_keys($list5);
+		$this->assertEquals(2, count($list5));  // only 1 since the id specified won't be included
+		$this->assertEquals('nonefination', $list[$listKeys5[0]]->getObjectType());
+		$this->assertEquals('notification', $list[$listKeys5[1]]->getObjectType());
+		$this->assertTrue($listKeys5[0] > $listKeys5[1]);
+		$this->assertEquals($listKeys[0], $listKeys5[0]);  // check the id of the notification
+		$this->assertEquals($listKeys[2], $listKeys5[1]);
+
+		$this->handler->delete($notification1);
+		$this->handler->delete($notification2);
+		$this->handler->delete($notification3);
+		$this->handler->delete($notification4);
+	}
+
+	public function testFetchAscendentList() {
+		$notification1 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'notification',
+			'getObjectId' => '1337',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification2 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user2',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'notifi-cat-ion',
+			'getObjectId' => '1338',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification3 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'blondification',
+			'getObjectId' => '1339',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$notification4 = $this->getNotification([
+			'getApp' => 'testing_notifications',
+			'getUser' => 'test_user1',
+			'getDateTime' => new \DateTime(),
+			'getObjectType' => 'nonefination',
+			'getObjectId' => '1340',
+			'getSubject' => 'subject',
+			'getSubjectParameters' => [],
+			'getMessage' => 'message',
+			'getMessageParameters' => [],
+			'getLink' => 'link',
+			'getActions' => [
+				[
+					'getLabel' => 'action_label',
+					'getLink' => 'action_link',
+					'getRequestType' => 'GET',
+					'isPrimary' => true,
+				]
+			],
+		]);
+		$this->handler->add($notification1);
+		$this->handler->add($notification2);
+		$this->handler->add($notification3);
+		$this->handler->add($notification4);
+
+		// fetch all the notifications (up to 20)
+		$list = $this->handler->fetchAscendentList('test_user1');
+		$listKeys = array_keys($list);
+		$this->assertEquals(3, count($list));
+		$this->assertEquals('notification', $list[$listKeys[0]]->getObjectType());
+		$this->assertEquals('blondification', $list[$listKeys[1]]->getObjectType());
+		$this->assertEquals('nonefination', $list[$listKeys[2]]->getObjectType());
+		$this->assertTrue($listKeys[0] < $listKeys[1]);
+		$this->assertTrue($listKeys[1] < $listKeys[2]);
+
+		$list2 = $this->handler->fetchAscendentList('test_user1', $listKeys[1]);
+		$listKeys2 = array_keys($list2);
+		$this->assertEquals(1, count($list2));  // only 1 since the id specified won't be included
+		$this->assertEquals('nonefination', $list[$listKeys2[0]]->getObjectType());
+		$this->assertEquals($listKeys[2], $listKeys2[0]);  // check the id of the notification
+
+		$list3 = $this->handler->fetchAscendentList('test_user1', null, 1);
+		$listKeys3 = array_keys($list3);
+		$this->assertEquals(1, count($list3));  // only 1 since the id specified won't be included
+		$this->assertEquals('notification', $list[$listKeys3[0]]->getObjectType());
+		$this->assertEquals($listKeys[0], $listKeys3[0]);  // check the id of the notification
+
+		$list4 = $this->handler->fetchAscendentList('test_user1', $listKeys[0], 1);
+		$listKeys4 = array_keys($list4);
+		$this->assertEquals(1, count($list4));  // only 1 since the id specified won't be included
+		$this->assertEquals('blondification', $list[$listKeys4[0]]->getObjectType());
+		$this->assertEquals($listKeys[1], $listKeys4[0]);  // check the id of the notification
+
+		$callableFunc = function(INotification $notification) {
+			if (strpos($notification->getObjectType(), 'no') === 0) {
+				return $notification;
+			} else {
+				return null;
+			}
+		};
+
+		$list5 = $this->handler->fetchAscendentList('test_user1', null, 20, $callableFunc);
+		$listKeys5 = array_keys($list5);
+		$this->assertEquals(2, count($list5));  // only 1 since the id specified won't be included
+		$this->assertEquals('notification', $list[$listKeys5[0]]->getObjectType());
+		$this->assertEquals('nonefination', $list[$listKeys5[1]]->getObjectType());
+		$this->assertTrue($listKeys5[0] < $listKeys5[1]);
+		$this->assertEquals($listKeys[0], $listKeys5[0]);  // check the id of the notification
+		$this->assertEquals($listKeys[2], $listKeys5[1]);
+
+		$this->handler->delete($notification1);
+		$this->handler->delete($notification2);
+		$this->handler->delete($notification3);
+		$this->handler->delete($notification4);
 	}
 
 	/**
@@ -173,7 +447,7 @@ class HandlerTest extends TestCase {
 	 * @return \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function getNotification(array $values = []) {
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
New notification API, being used by the webUI already. The old API is still available mainly for the desktop client.

New API focuses on efficient network usage specially if the user has several notifications pending, as well as long lists of notifications.

As part of the API changes, the usage of the web browser notification has changed, showing only the browser notification only once until further interaction with the ownCloud's notifications has been made. Once you "know" you have pending notifications, the browser won't bother you until you fetch all of pending notifications.
Note that the notification permission will be requested on page loading (when the component is being initialized) instead of when a new notification arrives. This might be a bit problematic on some scenarios if the browser permission hasn't been accepted or rejected beforehand.