### PR TITLE
Include the template folder in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ appstore:
 	img \
 	js \
 	lib \
+	templates \
 	$(appstore_package_name)
 
 ifdef CAN_SIGN


### PR DESCRIPTION
Template folder wasn't being included in the package, which leads to a crash. Package is correctly generated with this fix.