### PR TITLE
Adjust email message

### DIFF
--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -44,14 +44,10 @@ class NotificationMailer {
 	/** @var OptionsStorage */
 	private $optionsStorage;
 
-	/** @var IFactory */
-	private $l10nFactory;
-
-	public function __construct(IManager $manager, IMailer $mailer, OptionsStorage $optionsStorage, IFactory $l10nFactory) {
+	public function __construct(IManager $manager, IMailer $mailer, OptionsStorage $optionsStorage) {
 		$this->manager = $manager;
 		$this->mailer = $mailer;
 		$this->optionsStorage = $optionsStorage;
-		$this->l10nFactory = $l10nFactory;
 	}
 
 	/**
@@ -77,20 +73,18 @@ class NotificationMailer {
 		$emailMessage = $this->mailer->createMessage();
 		$emailMessage->setTo([$emailAddress]);
 
-		$l10n = $this->l10nFactory->get('notifications', $language);
-
-		$notificationObjectType = $notification->getObjectType();
-		$notificationObjectId = $notification->getObjectId();
-		$generatedId = "$notificationObjectType#$notificationObjectId";
-
-		$translatedSubject = (string)$l10n->t('You\'ve received a new notification in %s : "%s"', [$serverUrl, $generatedId]);
-		$emailMessage->setSubject($translatedSubject);
+		$notificationLink = $notification->getLink();
+		if ($notificationLink === '') {
+			$notificationLink = $serverUrl;
+		}
 
 		$parsedSubject = $notification->getParsedSubject();
 		$parsedMessage = $notification->getParsedMessage();
 
-		$htmlText = $this->getMailBody($parsedSubject, $parsedMessage, $serverUrl, 'mail/htmlmail');
-		$plainText = $this->getMailBody($parsedSubject, $parsedMessage, $serverUrl, 'mail/plaintextmail');
+		$emailMessage->setSubject($parsedSubject);
+
+		$htmlText = $this->getMailBody($parsedMessage, $notificationLink, 'mail/htmlmail');
+		$plainText = $this->getMailBody($parsedMessage, $notificationLink, 'mail/plaintextmail');
 
 		$emailMessage->setPlainBody($plainText);
 		$emailMessage->setHtmlBody($htmlText);
@@ -136,9 +130,8 @@ class NotificationMailer {
 		}
 	}
 
-	private function getMailBody($subject, $message, $serverUrl, $targetTemplate) {
+	private function getMailBody($message, $serverUrl, $targetTemplate) {
 		$tmpl = new Template('notifications', $targetTemplate, '', false);
-		$tmpl->assign('subject', $subject);
 		$tmpl->assign('message', $message);
 		$tmpl->assign('serverUrl', $serverUrl);
 		return $tmpl->fetchPage();

--- a/lib/Mailer/NotificationMailerAdapter.php
+++ b/lib/Mailer/NotificationMailerAdapter.php
@@ -86,11 +86,7 @@ class NotificationMailerAdapter {
 
 		if ($this->sender->validateEmail($targetEmail)) {
 			try {
-				$serverUrl = $notification->getLink();
-				if (empty($serverUrl)) {
-					$serverUrl = $this->urlGenerator->getAbsoluteURL('/');
-				}
-
+				$serverUrl = $this->urlGenerator->getAbsoluteURL('/');
 				$this->sender->sendNotification($notification, $serverUrl, $targetEmail);
 			} catch (\Exception $ex) {
 				$this->logger->logException($ex, ['app' => $this->appName]);

--- a/templates/mail/htmlmail.php
+++ b/templates/mail/htmlmail.php
@@ -11,11 +11,11 @@
 <tr>
 <td width="20px">&nbsp;</td>
 <td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
-<?php p($_['subject']); ?>
-<br /><br />
-<?php p($_['message']); ?>
-<br /><br />
-<?php print_unescaped($l->t('Go to <a href="%s">%s</a> to check the notification', [$_['serverUrl'], $_['serverUrl']])); ?>
+<?php if ($_['message'] !== ''): ?>
+	<?php p($_['message']); ?>
+	<br><br>
+<?php endif; ?>
+<?php print_unescaped($l->t('See <a href="%s">%s</a> for more information', [$_['serverUrl'], $_['serverUrl']])); ?>
 </td>
 </tr>
 <tr><td colspan="2">&nbsp;</td></tr>

--- a/templates/mail/plaintextmail.php
+++ b/templates/mail/plaintextmail.php
@@ -1,10 +1,10 @@
-<?php print_unescaped($_['subject']); ?>
-
-
+<?php if ($_['message'] !== ''): ?>
 <?php print_unescaped($_['message']); ?>
 
 
-<?php print_unescaped($l->t('Go to %s to check the notification', [$_['serverUrl']])); ?>
+<?php endif; ?>
+<?php print_unescaped($l->t('See %s for more information', [$_['serverUrl']])); ?>
+
 
 --
 <?php p($theme->getName() . ' - ' . $theme->getSlogan()); ?>

--- a/tests/Unit/Mailer/NotificationMailerAdapterTest.php
+++ b/tests/Unit/Mailer/NotificationMailerAdapterTest.php
@@ -272,7 +272,7 @@ class NotificationMailerAdapterTest extends \Test\TestCase {
 			->willReturn(true);
 		$this->notificationMailer->expects($this->once())
 			->method('sendNotification')
-			->with($mockedNotification, 'http://notification.com/link/here', 'we@we.we');
+			->with($mockedNotification, 'http://what.ever/oc', 'we@we.we');
 
 		$this->adapter->sendMail($mockedNotification);
 	}

--- a/tests/Unit/Mailer/NotificationMailerTest.php
+++ b/tests/Unit/Mailer/NotificationMailerTest.php
@@ -97,6 +97,7 @@ class NotificationMailerTest extends \Test\TestCase {
 		$mockedNotification->method('getObjectId')->willReturn('202');
 		$mockedNotification->method('getParsedSubject')->willReturn('This is a parsed subject');
 		$mockedNotification->method('getParsedMessage')->willReturn('Parsed message is this');
+		$mockedNotification->method('getLink')->willReturn('');
 
 		$this->manager->method('prepare')->willReturn($mockedNotification);
 
@@ -116,14 +117,10 @@ class NotificationMailerTest extends \Test\TestCase {
 		$sentMessage = $this->notificationMailer->sendNotification($mockedNotification, 'http://test.server/oc', 'test@example.com');
 
 		$this->assertEquals(['test@example.com' => null], $sentMessage->getTo());
-		// check that the subject contains the server url
-		$this->assertContains('http://test.server/oc', $sentMessage->getSubject());
-		// check the notification id is also present in the subject
-		$notifId = $mockedNotification->getObjectType() . "#" . $mockedNotification->getObjectId();
-		$this->assertContains($notifId, $sentMessage->getSubject());
+		// check that the notification subject is the email subject
+		$this->assertEquals('This is a parsed subject', $sentMessage->getSubject());
 
 		// notification's subject and message must be present in the email body, as well as the server url
-		$this->assertContains($mockedNotification->getParsedSubject(), $sentMessage->getPlainBody());
 		$this->assertContains($mockedNotification->getParsedMessage(), $sentMessage->getPlainBody());
 		$this->assertContains('http://test.server/oc', $sentMessage->getPlainBody());
 	}

--- a/tests/acceptance/features/apiNotifications/email-notifications.feature
+++ b/tests/acceptance/features/apiNotifications/email-notifications.feature
@@ -19,13 +19,11 @@ Feature: notifications-content
 			| object_id   | 9483                                                                      |
 		Then the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
-			Acceptance Testing
-			
 			About Activities and Notifications in ownCloud
 			
-			Go to https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/ to check the notification
+			See https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/ for more information
 			"""
 		And the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
-			Go to <a href="https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/">https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/</a> to check the notification</td>
+			See <a href="https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/">https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/</a> for more information</td>
 			"""


### PR DESCRIPTION
Email's title will contain the url of the server sending the notification, and the email's body will contain the notification's link. Previously, the notification's link was present in both title and body.

Partial fix of https://github.com/owncloud/notifications/issues/186 (more changes might be needed for a better message)