### PR TITLE
Fix notification not being sent by email if system cron is set

### DIFF
--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -137,7 +137,7 @@ class NotificationMailer {
 	}
 
 	private function getMailBody($subject, $message, $serverUrl, $targetTemplate) {
-		$tmpl = new Template('notifications', $targetTemplate);
+		$tmpl = new Template('notifications', $targetTemplate, '', false);
 		$tmpl->assign('subject', $subject);
 		$tmpl->assign('message', $message);
 		$tmpl->assign('serverUrl', $serverUrl);


### PR DESCRIPTION
### Steps to reproduce
1. Setup OC 10.0.8 code
2. Setup system cron
3. Make sure the update notification background job triggers and sends a notification (you might need to either change the update server to put a newer version or fake the version or your installation)
4. Let the cron.php job run or run it manually from the ownCloud server

### Actual behaviour
Exception is thrown and email isn't sent
```
{"reqId":"ctSPDH6FkuJxMXzspkDw","level":3,"time":"2018-05-29T08:05:06+00:00","remoteAddr":"","user":"--","app":"notifications","method":"--","url":"--","message":"Exception: {\"Exception\":\"OCP\\\\Session\\\\Exceptions\\\\SessionNotAvailableException\",\"Message\":\"Session has been closed - no further changes to the session are allowed\",\"Code\":0,\"Trace\":\"#0 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Session\\\/Memory.php(52): OC\\\\Session\\\\Memory->validateSession()\\n#1 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Security\\\/CSRF\\\/TokenStorage\\\/SessionStorage.php(63): OC\\\\Session\\\\Memory->set('requesttoken', 'LTxXex2UzjmhadM...')\\n#2 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Security\\\/CSRF\\\/CsrfTokenManager.php(57): OC\\\\Security\\\\CSRF\\\\TokenStorage\\\\SessionStorage->setToken('LTxXex2UzjmhadM...')\\n#3 \\\/var\\\/www\\\/owncloud\\\/lib\\\/public\\\/Util.php(511): OC\\\\Security\\\\CSRF\\\\CsrfTokenManager->getToken(*** sensitive parameters replaced ***)\\n#4 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/legacy\\\/template.php(82): OCP\\\\Util::callRegister()\\n#5 \\\/var\\\/www\\\/owncloud\\\/apps\\\/notifications\\\/lib\\\/Mailer\\\/NotificationMailer.php(145): OC_Template->__construct('notifications', 'mail\\\/htmlmail')\\n#6 \\\/var\\\/www\\\/owncloud\\\/apps\\\/notifications\\\/lib\\\/Mailer\\\/NotificationMailer.php(97): OCA\\\\Notifications\\\\Mailer\\\\NotificationMailer->getMailBody('Update for ownC...', '', 'http:\\\/\\\/localhos...', 'mail\\\/htmlmail')\\n#7 \\\/var\\\/www\\\/owncloud\\\/apps\\\/notifications\\\/lib\\\/Mailer\\\/NotificationMailerAdapter.php(90): OCA\\\\Notifications\\\\Mailer\\\\NotificationMailer->sendNotification(Object(OC\\\\Notification\\\\Notification), 'http:\\\/\\\/localhos...', 'admin@example.c...')\\n#8 \\\/var\\\/www\\\/owncloud\\\/apps\\\/notifications\\\/lib\\\/App.php(49): OCA\\\\Notifications\\\\Mailer\\\\NotificationMailerAdapter->sendMail(Object(OC\\\\Notification\\\\Notification))\\n#9 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Notification\\\/Manager.php(241): OCA\\\\Notifications\\\\App->notify(Object(OC\\\\Notification\\\\Notification))\\n#10 \\\/var\\\/www\\\/owncloud\\\/apps\\\/updatenotification\\\/lib\\\/Notification\\\/BackgroundJob.php(128): OC\\\\Notification\\\\Manager->notify(Object(OC\\\\Notification\\\\Notification))\\n#11 \\\/var\\\/www\\\/owncloud\\\/apps\\\/updatenotification\\\/lib\\\/Notification\\\/BackgroundJob.php(98): OCA\\\\UpdateNotification\\\\Notification\\\\BackgroundJob->createNotifications('core', '10.0.8', 'http:\\\/\\\/localhos...')\\n#12 \\\/var\\\/www\\\/owncloud\\\/apps\\\/updatenotification\\\/lib\\\/Notification\\\/BackgroundJob.php(81): OCA\\\\UpdateNotification\\\\Notification\\\\BackgroundJob->checkCoreUpdate()\\n#13 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/Job.php(57): OCA\\\\UpdateNotification\\\\Notification\\\\BackgroundJob->run(NULL)\\n#14 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/BackgroundJob\\\/TimedJob.php(53): OC\\\\BackgroundJob\\\\Job->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#15 \\\/var\\\/www\\\/owncloud\\\/cron.php(120): OC\\\\BackgroundJob\\\\TimedJob->execute(Object(OC\\\\BackgroundJob\\\\JobList), Object(OC\\\\Log))\\n#16 {main}\",\"File\":\"\\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Session\\\/Memory.php\",\"Line\":120}"}
```

This PR fixes this issue and allow sending the notification via email as expected.