### PR TITLE
Fix migration from 8.2.11 to 10.0.x with postgresql

### DIFF
--- a/appinfo/Migrations/Version20180604132522.php
+++ b/appinfo/Migrations/Version20180604132522.php
@@ -1,0 +1,21 @@
+<?php
+namespace OCA\notifications\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Change the type of the 'object_id' column from integer to string
+ * Migration step required to update from ownCloud 8.2.x
+ */
+class Version20180604132522 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}notifications");
+		$column = $table->getColumn('object_id');
+		if ($column->getType() === Type::getType(Type::INTEGER)) {
+			$column->setType(Type::getType(Type::STRING));
+		}
+	}
+}


### PR DESCRIPTION
Target scenario should be fixed with this.
There are other scenarios not tested at the moment such as migrations from 9.0.x and 9.1.x but I don't expect problems with them (forcing the datatype shouldn't cause issues).

Note that the fix won't affect installations that have been already migrated. Those installations are expected to be manually fixed already.