### PR TITLE
Add stable10 to branches list to match with yml in stable10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /var/www/owncloud
   path: apps/notifications
 
-branches: [master, release*, release/*]
+branches: [master, stable10, release*, release/*]
 
 pipeline:
   install-server:


### PR DESCRIPTION
This makes the ``branches`` list the same in both ``stable10`` and ``master`` - which avoids dumb conflicts when this line is modified.