### PR TITLE
[stable10] Include the product name in the mail for the notifications

### DIFF
--- a/templates/mail/htmlmail.php
+++ b/templates/mail/htmlmail.php
@@ -16,7 +16,7 @@ Hello,<br>
 	<?php p($_['message']); ?>
 	<br><br>
 <?php endif; ?>
-<?php print_unescaped($l->t('See <a href="%s">%s</a> for more information', [$_['serverUrl'], $_['serverUrl']])); ?>
+<?php print_unescaped($l->t('See <a href="%s">%s</a> on %s for more information', [$_['serverUrl'], $_['serverUrl'], $theme->getName()])); ?>
 </td>
 </tr>
 <tr><td colspan="2">&nbsp;</td></tr>

--- a/templates/mail/plaintextmail.php
+++ b/templates/mail/plaintextmail.php
@@ -4,7 +4,7 @@ Hello,
 
 
 <?php endif; ?>
-<?php print_unescaped($l->t('See %s for more information', [$_['serverUrl']])); ?>
+<?php print_unescaped($l->t('See %s on %s for more information', [$_['serverUrl'], $theme->getName()])); ?>
 
 
 <?php print_unescaped($this->inc('plain.mail.footer', ['app' => 'core'])); ?>

--- a/tests/acceptance/features/apiNotifications/email-notifications.feature
+++ b/tests/acceptance/features/apiNotifications/email-notifications.feature
@@ -19,11 +19,13 @@ Feature: notifications-content
 			| object_id   | 9483                                                                      |
 		Then the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
+			Hello,
 			About Activities and Notifications in ownCloud
 			
-			See https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/ for more information
+			See https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/ on ownCloud for more information
 			"""
 		And the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
-			See <a href="https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/">https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/</a> for more information</td>
+			See <a href="https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/">https://owncloud.org/blog/about-activities-and-notifications-in-owncloud/</a> on ownCloud for more information</td>
 			"""
+


### PR DESCRIPTION
Backport of https://github.com/owncloud/notifications/pull/210 to stable10

Partial fix for https://github.com/owncloud/core/issues/31876