### PR TITLE
[WIP] notification of share through email moved to background job

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,10 @@
 		<personal>OCA\Notifications\Panels\Personal\NotificationsPanel</personal>
 	</settings>
 
+	<background-jobs>
+		<job>OCA\Notifications\Background\MailNotificationSender</job>
+	</background-jobs>
+
 	<dependencies>
 		<owncloud min-version="10.0.9" max-version="10.1" />
 	</dependencies>

--- a/lib/BackgroundJob/MailNotificationSender.php
+++ b/lib/BackgroundJob/MailNotificationSender.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Notifications\BackgroundJob;
+
+use OC\BackgroundJob\Job;
+use OC\User\Manager;
+use OCA\Notifications\Configuration\OptionsStorage;
+use OCA\Notifications\Mailer\NotificationMailer;
+use OCA\Notifications\Mailer\NotificationMailerAdapter;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\Mail\IMailer;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Notification\IManager as NotificationManager;
+
+/**
+ * Class MailNotificationSender
+ *
+ * @package OCA\Notifications\BackgroundJob
+ */
+class MailNotificationSender extends Job {
+
+	/** @var IManager  */
+	private $shareManager;
+
+	/** @var \OC\Group\Manager|IGroupManager  */
+	private $groupManager;
+
+	/** @var Manager  */
+	private $userManager;
+
+	/** @var NotificationManager  */
+	private $notificationManager;
+
+	/** @var IConfig  */
+	private $config;
+
+	/** @var IMailer  */
+	private $mailer;
+
+	/** @var NotificationMailerAdapter  */
+	private $mailerAdapter;
+
+	/** @var IURLGenerator  */
+	private $urlGenerator;
+
+	/** @var IRequest  */
+	private $request;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(IManager $shareManager = null,
+								IGroupManager $groupManager = null,
+								Manager $userManager = null,
+								NotificationManager $notificationManager = null,
+								NotificationMailerAdapter $mailerAdapter = null,
+								IMailer $mailer = null,
+								IConfig $config = null,
+								IURLGenerator $urlGenerator = null,
+								IRequest $request = null,
+								ILogger $logger = null) {
+		$this->shareManager = $shareManager ? $shareManager : \OC::$server->getShareManager();
+		$this->groupManager = $groupManager ? $groupManager : \OC::$server->getGroupManager();
+		$this->userManager = $userManager ? $userManager : \OC::$server->getUserManager();
+		$this->notificationManager = $notificationManager ? $notificationManager : \OC::$server->getNotificationManager();
+		$this->urlGenerator = $urlGenerator ? $urlGenerator : \OC::$server->getURLGenerator();
+		$this->request = $request ? $request : \OC::$server->getRequest();
+		$this->logger = $logger ? $logger : \OC::$server->getLogger();
+		$this->mailer = $mailer ? $mailer : \OC::$server->getMailer();
+		$this->config = $config ? $config : \OC::$server->getConfig();
+
+		$optionsStorage = new OptionsStorage($this->config);
+		$notificationMailer = new NotificationMailer($this->notificationManager, $this->mailer, $optionsStorage);
+
+		$this->mailerAdapter = $mailerAdapter ? $mailerAdapter :
+			new NotificationMailerAdapter($notificationMailer, $this->userManager, $this->logger, $this->urlGenerator);
+	}
+
+	/**
+	 * @param $notificationURL
+	 * @return string
+	 */
+	public function fixURL($notificationURL) {
+		$url = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+		$partURL = \explode($url, $notificationURL)[1];
+		$webRoot = $this->getArgument()['webroot'];
+		if (\strpos($partURL, $webRoot) === false) {
+			$notificationURL = $url . $this->getArgument()['webroot'] . $partURL;
+		}
+		return $notificationURL;
+	}
+
+	/**
+	 * @param $shareFullId
+	 */
+	public function sendNotify($shareFullId) {
+		$notificationList = [];
+		$maxCountSendNotification = 100;
+
+		//Check if its an internal share or not
+		try {
+			$share = $this->shareManager->getShareById($shareFullId);
+		} catch (ShareNotFound $e) {
+			return null;
+		}
+
+		$users = [];
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			//Notify all the group members
+			$group = $this->groupManager->get($share->getSharedWith());
+			$users = $group->getUsers();
+		} elseif ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+			$users[] = $this->userManager->get($share->getSharedWith());
+		}
+
+		foreach ($users as $user) {
+			if ($user->getEMailAddress() === null) {
+				\OC::$server->getLogger()->warning("Mail notification can not be sent to " . $user->getUID() . " for share " . $share->getName() .  " as email for user is not set");
+				continue;
+			}
+			$notification = $this->notificationManager->createNotification();
+			$notification->setApp('files_sharing')
+				->setUser($user->getUID())
+				->setDateTime(new \DateTime())
+				->setObject('local_share', $shareFullId);
+
+			$fileLink = $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileId' => $share->getNode()->getId()]);
+
+			$fileLink = $this->fixURL($fileLink);
+			$notification->setLink($fileLink);
+
+			$notification->setSubject('local_share', [$share->getShareOwner(), $share->getSharedBy(), $share->getNode()->getName()]);
+			$notification->setMessage('local_share', [$share->getShareOwner(), $share->getSharedBy(), $share->getNode()->getName()]);
+
+			//Adding action because sendMail requires an action for the notificaiton
+			$acceptAction = $notification->createAction();
+			$acceptAction->setLabel('email');
+			$acceptAction->setLink($fileLink, 'POST');
+			$notification->addAction($acceptAction);
+
+			if (\count($notificationList) < $maxCountSendNotification) {
+				$notificationList[] = $notification;
+			} else {
+				foreach ($notificationList as $notificationDispatch) {
+					$this->mailerAdapter->sendMail($notificationDispatch);
+				}
+
+				//Once users in notificationList recieve notification reset the list
+				$notificationList = [$notification];
+			}
+		}
+
+		if (\count($notificationList) < $maxCountSendNotification) {
+			foreach ($notificationList as $notificationDispatch) {
+				$this->mailerAdapter->sendMail($notificationDispatch);
+			}
+		}
+	}
+
+	protected function run($argument) {
+		if (($this->getArgument()['shareFullId'] === null) || ($this->getArgument()['webroot'] === null)) {
+			$this->logger->debug(__METHOD__ . " To execute this background job shareFullId and webroot are required. Aborting the job");
+		} else {
+			$this->sendNotify($this->getArgument()['shareFullId']);
+		}
+		\OC::$server->getJobList()->removeById($this->getId());
+	}
+}

--- a/tests/Unit/BackgroundJob/MailNotificationSenderTest.php
+++ b/tests/Unit/BackgroundJob/MailNotificationSenderTest.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Notifications\Tests\BackgroundJob;
+
+use OC\Group\Group;
+use OC\Notification\Action;
+use OC\User\Manager;
+use OCA\Notifications\BackgroundJob\MailNotificationSender;
+use OCA\Notifications\Mailer\NotificationMailerAdapter;
+use OCA\Notifications\Tests\Unit\TestCase;
+use OCP\Files\Node;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Mail\IMailer;
+use OCP\Notification\INotification;
+use OCP\Share\IManager;
+use OCP\Notification\IManager as NotificationManager;
+use OCP\Share\IShare;
+
+class MailNotificationSenderTest extends TestCase {
+
+	/** @var \OCP\Share\IManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $shareManager;
+
+	/** @var \OCP\IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $groupManager;
+
+	/** @var \OC\User\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+
+	/** @var NotificationManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $notificationManager;
+
+	/** @var \OCA\Notifications\Mailer\NotificationMailerAdapter | \PHPUnit_Framework_MockObject_MockObject */
+	private $mailerAdapter;
+
+	/** @var \OCP\Mail\IMailer | \PHPUnit_Framework_MockObject_MockObject */
+	private $mailer;
+
+	/** @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
+	/** @var \OCP\IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	private $urlGenerator;
+
+	/** @var \OCP\IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var \OCP\ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
+	/** @var \OCA\Notifications\BackgroundJob\MailNotificationSender | \PHPUnit_Framework_MockObject_MockObject */
+	private $mailNotificationSender;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(Manager::class);
+		$this->notificationManager = $this->createMock(NotificationManager::class);
+		$this->mailerAdapter = $this->createMock(NotificationMailerAdapter::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->mailNotificationSender = new MailNotificationSender($this->shareManager, $this->groupManager,
+			$this->userManager, $this->notificationManager, $this->mailerAdapter, $this->mailer, $this->config,
+			$this->urlGenerator, $this->request, $this->logger);
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	private function createShare() {
+		$node = $this->createMock(Node::class);
+		$node->method('getId')->willReturn(4000);
+		$node->method('getName')->willReturn('node-name');
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn(12300);
+		$share->method('getShareOwner')->willReturn('shareOwner');
+		$share->method('getSharedBy')->willReturn('sharedBy');
+		$share->method('getNode')->willReturn($node);
+
+		return $share;
+	}
+
+	private function makeGroup($groupName, $members) {
+		$memberObjects = \array_map(function ($memberName) {
+			$memberObject = $this->createMock(IUser::class);
+			$memberObject->method('getUID')->willReturn($memberName);
+			$memberObject->method('getEmailAddress')->willReturn('foo@bar.com');
+			return $memberObject;
+		}, $members);
+
+		$group = $this->createMock(IGroup::class);
+		$group->expects($this->once())
+			->method('getUsers')
+			->willReturn($memberObjects);
+
+		$this->groupManager->expects($this->any())
+			->method('get')
+			->with($groupName)
+			->willReturn($group);
+
+		return $memberObjects;
+	}
+
+	public function testGroupNotification() {
+		$share = $this->createShare();
+		$share->expects($this->exactly(1))
+			->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_GROUP);
+		$share->expects($this->once())
+			->method('getSharedWith')
+			->willReturn('group1');
+
+		$userIds = [];
+		for ($i = 1; $i <= 105; $i++) {
+			$userIds[] = 'user' . (string) $i;
+		}
+		$iUsers = $this->makeGroup('group1', $userIds);
+
+		$group = $this->createMock(Group::class);
+		$this->groupManager->expects($this->once())
+			->method('get')
+			->willReturn($group);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareById')
+			->willReturn($share);
+
+		$this->request->expects($this->exactly(105))
+			->method('getServerProtocol')
+			->willReturn('http');
+		$this->request->expects($this->exactly(105))
+			->method('getServerHost')
+			->willReturn('foo');
+
+		$this->urlGenerator->expects($this->exactly(105))
+			->method('linkToRouteAbsolute')
+			->willReturn('http://foo/bar/index.php/f/22');
+
+		$action = $this->createMock(Action::class);
+
+		$inotification = $this->createMock(INotification::class);
+		$this->notificationManager->expects($this->exactly(105))
+			->method('createNotification')
+			->willReturn($inotification);
+
+		$inotification->expects($this->exactly(105))
+			->method('setApp')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setUser')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setDateTime')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setObject')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setLink')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setSubject')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('setMessage')
+			->willReturn($inotification);
+		$inotification->expects($this->exactly(105))
+			->method('createAction')
+			->willReturn($action);
+		$inotification->expects($this->exactly(105))
+			->method('addAction')
+			->willReturnMap([
+				[$action, $inotification],
+			]);
+
+		for ($i = 1; $i <= 105; $i++) {
+			$action->expects($this->exactly(105))
+				->method('setLabel')
+				->willReturn($action);
+			$action->expects($this->exactly(105))
+				->method('setLink')
+				->willReturn($action);
+
+			$this->mailerAdapter->expects($this->exactly(105))
+				->method('sendMail')
+				->with($inotification);
+		}
+
+		$this->mailNotificationSender->sendNotify('ocinternal:' . $share->getId());
+	}
+
+	public function testSingleUserShareNotification() {
+		$share = $this->createShare();
+		$share->expects($this->exactly(2))
+			->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_USER);
+
+		$this->request->expects($this->exactly(1))
+			->method('getServerProtocol')
+			->willReturn('http');
+		$this->request->expects($this->exactly(1))
+			->method('getServerHost')
+			->willReturn('foo');
+
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->willReturn('http://foo/bar/index.php/f/22');
+
+		$emailAction = $this->createMock(Action::class);
+		$emailAction->expects($this->once())
+			->method('setLabel')
+			->willReturn($emailAction);
+		$emailAction->expects($this->once())
+			->method('setLink')
+			->willReturn($emailAction);
+
+
+		$inotification = $this->createMock(INotification::class);
+		$inotification->expects($this->once())
+			->method('setApp')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setUser')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setDateTime')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setObject')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setLink')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setSubject')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('setMessage')
+			->willReturn($inotification);
+		$inotification->expects($this->once())
+			->method('createAction')
+			->willReturn($emailAction);
+		$inotification->expects($this->once())
+			->method('addAction')
+			->willReturn($inotification);
+
+		$this->notificationManager->expects($this->once())
+			->method('createNotification')
+			->willReturn($inotification);
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('foo@bar.com');
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$this->shareManager->expects($this->once())
+			->method('getShareById')
+			->willReturn($share);
+		$this->mailNotificationSender->sendNotify($share->getId());
+	}
+}


### PR DESCRIPTION
It is better to move the notification of share using
email to background job. This prevents timeout or long
time wait to notify the user(s).

Signed-off-by: Sujith H <sharidasan@owncloud.com>