### PR TITLE
Remove unneeded SKELETON_DIR in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,6 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://owncloud
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - BEHAT_SUITE=${BEHAT_SUITE}
       - APPS_TO_ENABLE=notifications


### PR DESCRIPTION
SKELETON_DIR should have a correct default value in ``run.sh``, so it should not be needed here.

This will effectively implement the recent change of SKELETON_DIR location in core.