### PR TITLE
Register Symfony listener for testing events

### DIFF
--- a/tests/Unit/AppInfo/ApplicationTest.php
+++ b/tests/Unit/AppInfo/ApplicationTest.php
@@ -48,6 +48,7 @@ class ApplicationTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 		$this->app = new Application();
+		$this->app->setupSymfonyEventListeners();
 		$this->container = $this->app->getContainer();
 	}
 


### PR DESCRIPTION
Should fix https://github.com/owncloud/update-testing/issues/10

Because we can't expect the event to work if we didn't register it.
The fact that it worked so far was just pure luck...