### PR TITLE
Allow max-version 11.0.0.* so CI runs for developers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@
 	</settings>
 
 	<dependencies>
-		<owncloud min-version="10.0.9" max-version="11.0.0.0" />
+		<owncloud min-version="10.0.9" max-version="11.0.0" />
 	</dependencies>
 	<use-migrations>true</use-migrations>
 </info>


### PR DESCRIPTION
1) notifications app is installed, enabled and used by some core acceptance test suites
2) when developers bump the core master version because their PR has a DB migration, then they need notifications app max-version to cope with that

For now, we can put max-version ``11.0.0`` here, while there is no release happening.

Currently when we need to release the app, then we are backing out max-version to 10.* anyway. So we will not actually release notifications app just yet with max-version ``11.0.0``

When we sort out the semver changes, then we can adjust again.