### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -204,7 +204,7 @@ matrix:
     - PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       TEST_SUITE: owncloud-coding-standard
 
     # Unit Tests
@@ -235,14 +235,6 @@ matrix:
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -382,7 +374,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUINotifications
@@ -392,7 +384,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUINotifications
@@ -402,7 +394,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUINotifications
@@ -412,7 +404,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiNotifications
@@ -422,7 +414,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiNotifications
@@ -432,7 +424,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiNotifications
@@ -442,7 +434,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: cli-acceptance
       BEHAT_SUITE: cliNotifications
@@ -452,7 +444,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: cli-acceptance
       BEHAT_SUITE: cliNotifications
@@ -462,7 +454,7 @@ matrix:
       NEED_INSTALL_APP: true
       NEED_SERVER: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: cli-acceptance
       BEHAT_SUITE: cliNotifications

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@
 	</settings>
 
 	<dependencies>
-		<owncloud min-version="10.0.9" max-version="11" />
+		<owncloud min-version="10.2" max-version="11" />
 	</dependencies>
 	<use-migrations>true</use-migrations>
 </info>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "owncloud/notifications",
     "config": {
         "platform": {
-            "php": "5.6.37"
+            "php": "7.0.8"
         }
     },
     "require": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7021669270ef3ca7c3eb62f1490ac881",
+    "content-hash": "edd63867a0789d464b9df49699389f00",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698

- [x] adjust drone to no longer use PHP 5.6 anywhere
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`