### PR TITLE
create the user with default attributes (including email addr)

### DIFF
--- a/tests/acceptance/features/apiNotifications/email-notifications.feature
+++ b/tests/acceptance/features/apiNotifications/email-notifications.feature
@@ -2,9 +2,7 @@
 Feature: notifications-content
 
   Background:
-    Given these users have been created:
-      | username |
-      | user1    |
+    Given user "user1" has been created with default attributes
     And using OCS API version "2"
 
   Scenario: Create notification


### PR DESCRIPTION
there was a fix for
`Given these users have been created: # FeatureContext::theseUsersHaveBeenCreated()`
so when is there is no email address in the table no email address will be set https://github.com/owncloud/core/pull/34810
the notification test did not set it, so it failed