### PR TITLE
Phpunit 5 6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7"
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/62fef740245a85f00665e81ea8f0aa0b72afe6e7",
-                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/67f9d314dc7ecf7245b8637906e151ccc62b8d24",
+                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "composer/composer": "dev-master",
-                "symfony/console": "^2.5 || ^3.0"
+                "symfony/console": "^2.5 || ^3.0 || ^4.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -44,7 +44,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2017-09-11T13:13:58+00:00"
+            "time": "2019-03-17T12:38:04+00:00"
         }
     ],
     "aliases": [],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,8 +28,6 @@ use OCA\Notifications\App as NotificationApp;
 use OCA\Notifications\Notifier;
 use OCP\AppFramework\App;
 use OCP\IContainer;
-use OCP\IUser;
-use OCP\IUserSession;
 use OCP\Notification\Events\RegisterConsumerEvent;
 use OCP\Notification\Events\RegisterNotifierEvent;
 use Symfony\Component\EventDispatcher\GenericEvent;

--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -24,7 +24,6 @@ namespace OCA\Notifications\Controller;
 use OC\OCS\Result;
 use OCA\Notifications\Handler;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Controller;
 use OCP\AppFramework\OCSController;
 use OCP\IConfig;
 use OCP\IRequest;

--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -24,9 +24,6 @@ namespace OCA\Notifications\Mailer;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Mail\IMailer;
-use OCP\IConfig;
-use OCP\L10N\IFactory;
-use OCP\Util;
 use OCP\Template;
 use OCA\Notifications\Configuration\OptionsStorage;
 

--- a/lib/Mailer/NotificationMailerAdapter.php
+++ b/lib/Mailer/NotificationMailerAdapter.php
@@ -21,12 +21,10 @@
 
 namespace OCA\Notifications\Mailer;
 
-use OCP\Notification\IApp;
 use OCP\Notification\INotification;
 use OCP\IUserManager;
 use OCP\ILogger;
 use OCP\IURLGenerator;
-use OCA\Notifications\Mailer\NotificationMailer;
 
 /**
  * Send notifications via mail. This class acts as an adapter of the NotificationMailer and the

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,8 @@
 <phpunit bootstrap="../../tests/bootstrap.php"
 		 strict="true"
 		 verbose="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"

--- a/tests/Unit/AppInfo/AppTest.php
+++ b/tests/Unit/AppInfo/AppTest.php
@@ -32,11 +32,11 @@ use OCP\IUser;
  * @package OCA\Notifications\Tests\AppInfo
  */
 class AppTest extends TestCase {
-	/** @var \OCP\Notification\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Notification\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
 	protected function setUp() {

--- a/tests/Unit/AppInfo/ApplicationTest.php
+++ b/tests/Unit/AppInfo/ApplicationTest.php
@@ -75,7 +75,7 @@ class ApplicationTest extends TestCase {
 
 	/**
 	 * @param array $values
-	 * @return \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getNotification(array $values = []) {
 		$notification = $this->getMockBuilder('OCP\Notification\INotification')

--- a/tests/Unit/AppInfo/ApplicationTest.php
+++ b/tests/Unit/AppInfo/ApplicationTest.php
@@ -22,13 +22,9 @@
 
 namespace OCA\Notifications\Tests\Unit\AppInfo;
 
-use OC\AppFramework\DependencyInjection\DIContainer;
 use OCA\Notifications\AppInfo\Application;
 use OCA\Notifications\Handler;
 use OCA\Notifications\Tests\Unit\TestCase;
-use OCP\IServerContainer;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\Traits\UserTrait;
 
 /**

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -28,13 +28,13 @@ use OCA\Notifications\Handler;
 use OCA\Notifications\Mailer\NotificationMailerAdapter;
 
 class AppTest extends TestCase {
-	/** @var \OCA\Notifications\Handler|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Notifications\Handler|\PHPUnit\Framework\MockObject\MockObject */
 	protected $handler;
 
-	/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject */
 	protected $notification;
 
-	/** @var NotificationMailerAdapter|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var NotificationMailerAdapter|\PHPUnit\Framework\MockObject\MockObject */
 	protected $mailerAdapter;
 
 	/** @var \OCA\Notifications\App */

--- a/tests/Unit/Command/GenerateTest.php
+++ b/tests/Unit/Command/GenerateTest.php
@@ -33,15 +33,15 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class GenerateTest extends TestCase {
 
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
-	/** @var IManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
 	/** @var Generate */
 	protected $command;
 	/** @var CommandTester */
 	protected $tester;
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
 	protected function setUp() {

--- a/tests/Unit/Controller/EndpointControllerTest.php
+++ b/tests/Unit/Controller/EndpointControllerTest.php
@@ -28,56 +28,56 @@ use OCA\Notifications\Tests\Unit\TestCase;
 use OCP\AppFramework\Http;
 
 class EndpointControllerTest extends TestCase {
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCA\Notifications\Handler|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Notifications\Handler|\PHPUnit\Framework\MockObject\MockObject */
 	protected $handler;
 
-	/** @var \OCP\Notification\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Notification\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
 	/** @var EndpointController */
 	protected $controller;
 
-	/** @var \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
 
 	protected function setUp() {
 		parent::setUp();
 
-		/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 		$this->request = $this->getMockBuilder('OCP\IRequest')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCA\Notifications\Handler|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCA\Notifications\Handler|\PHPUnit\Framework\MockObject\MockObject */
 		$this->handler = $this->getMockBuilder('OCA\Notifications\Handler')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\Notification\IManager|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCP\Notification\IManager|\PHPUnit\Framework\MockObject\MockObject */
 		$this->manager = $this->getMockBuilder('OCP\Notification\IManager')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 		$this->config = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 		$this->session = $this->getMockBuilder('OCP\IUserSession')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 		$this->user = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -236,7 +236,7 @@ class HandlerTest extends TestCase {
 
 	/**
 	 * @param array $values
-	 * @return \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject
+	 * @return \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getNotification(array $values = []) {
 		$notification = $this->getMockBuilder('OCP\Notification\INotification')

--- a/tests/Unit/Mailer/NotificationMailerTest.php
+++ b/tests/Unit/Mailer/NotificationMailerTest.php
@@ -21,7 +21,6 @@
 
 namespace OCA\Notifications\Tests\Unit\Mailer;
 
-use OC\Mail\Message;
 use OC\Mail\Mailer;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;

--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Client;
+use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -73,8 +74,8 @@ class NotificationsContext implements Context {
 	public function userHasBeenSentANotification($user) {
 		$this->userIsSentANotification($user);
 		$response = $this->featureContext->getResponse();
-		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(200, $response->getStatusCode());
+		Assert::assertEquals(
 			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
 		);
 	}
@@ -138,8 +139,8 @@ class NotificationsContext implements Context {
 	public function userHasBeenSentANotificationWith($user, TableNode $formData) {
 		$this->userIsSentANotificationWith($user, $formData);
 		$response = $this->featureContext->getResponse();
-		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(200, $response->getStatusCode());
+		Assert::assertEquals(
 			200, (int) $this->ocsContext->getOCSResponseStatusCode($response)
 		);
 	}
@@ -239,19 +240,19 @@ class NotificationsContext implements Context {
 
 		$this->setCSRFDotDisabled($oldCSRFSetting);
 
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			200, $response->getStatusCode(),
 			"could not set notification option " . $response->getReasonPhrase()
 		);
 		$responseDecoded = \json_decode($response->getBody());
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$responseDecoded->data->options->id, $user,
 			"Could not set notification option! " .
 			"'user' in the response is:'" .
 			$responseDecoded->data->options->id . "' " .
 			"but should be: '$user'"
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$responseDecoded->data->options->email_sending_option, $setting,
 			"Could not set notification option! " .
 			"'email_sending_option' in the response is:'" .
@@ -284,7 +285,7 @@ class NotificationsContext implements Context {
 	 * @return void
 	 */
 	public function deleteNotification($user, $firstOrLast) {
-		PHPUnit_Framework_Assert::assertNotEmpty(
+		Assert::assertNotEmpty(
 			$this->notificationsCoreContext->getNotificationIds()
 		);
 		$lastNotificationIds


### PR DESCRIPTION
1) Adjust PHPUnit Framework namespace for PHPUnit6 
2) phpunit enable failOnRisky failOnWarning 
3) remove unused use statements 
4) Updating bamarni/composer-bin-plugin (v1.2.0 => v1.3.0)
