### PR TITLE
Merge stable10 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Set max version to platform version 10 for future 10.x releases - [#251](https://github.com/owncloud/notifications/issues/251)
+
+## [0.3.5]
+
+- Added translations - [#233](https://github.com/owncloud/notifications/issues/233)
+- Clear user notifications after user deletion - [#223](https://github.com/owncloud/notifications/issues/223) [#238](https://github.com/owncloud/notifications/issues/238)
+- Include the product name in the mail for the notifications - [#211](https://github.com/owncloud/notifications/issues/211)
+- Add "hello" in the mail templates - [#209](https://github.com/owncloud/notifications/issues/209)
+- Add common footer to notifications - [#207](https://github.com/owncloud/notifications/issues/207)
+
+## [0.3.4]
+
+- Fix migration from 8.2.11 to 10.0.x with postgresql - [#195](https://github.com/owncloud/notifications/issues/195)
+- Adjust email message for notifications to be more user-friendly - [#188](https://github.com/owncloud/notifications/issues/188)
+
+## [0.3.3]
+
+- Allow CORS requests to list notifications - [#176](https://github.com/owncloud/notifications/issues/176)
+- Include the template folder in the Makefile - [#168](https://github.com/owncloud/notifications/issues/168)
+- Add support for email notifications - [#156](https://github.com/owncloud/notifications/issues/156) [#162](https://github.com/owncloud/notifications/issues/162) [#175](https://github.com/owncloud/notifications/issues/175) [#171](https://github.com/owncloud/notifications/issues/171)
+- Add occ command arguments for link and link text - [#172](https://github.com/owncloud/notifications/issues/172)
+- Fix occ command for group notification - [#146](https://github.com/owncloud/notifications/issues/146)
+
+## [0.3.2]
+### Fixed
+- Fix login page URL detection which caused trouble with shibboleth users - [#122](https://github.com/owncloud/notifications/issues/122)
+
+## [0.3.1]
 ### Added
 - Notifications can now have an icon - [#104](https://github.com/owncloud/notifications/issues/104)
 - Added occ command to send notification to a user or a grouop - [#104](https://github.com/owncloud/notifications/issues/104)
@@ -16,5 +44,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Move OCS calls to app framework - consumes less resources - [#98](https://github.com/owncloud/notifications/pull/98)
 - Don't use escaped message for browser notification - [#100](https://github.com/owncloud/notifications/pull/100)
 
-[Unreleased]: https://github.com/owncloud/core/compare/v10.0.2...stable10
+[Unreleased]: https://github.com/owncloud/notifications/compare/v10.0.10...stable10
+[0.3.5]: https://github.com/owncloud/notifications/compare/v10.0.9...v10.0.10
+[0.3.4]: https://github.com/owncloud/notifications/compare/v10.0.8...v10.0.9
+[0.3.3]: https://github.com/owncloud/notifications/compare/v10.0.4...v10.0.8
+[0.3.2]: https://github.com/owncloud/notifications/compare/v10.0.3...v10.0.4
+[0.3.1]: https://github.com/owncloud/notifications/compare/v10.0.2...v10.0.4RC2
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<screenshot>https://raw.githubusercontent.com/owncloud/promo/e1dd604d66b4c5f765579b4c160de3268169ea3c/ownCloud%20logo%20square.png</screenshot>
 
 	<licence>AGPL</licence>
-	<author>Joas Schilling, Thomas Müller</author>
+	<author>Joas Schilling, Thomas Müller, Juan Pablo Villafañez</author>
 	<version>0.4.1</version>
 
 	<types>
@@ -30,7 +30,7 @@
 	</settings>
 
 	<dependencies>
-		<owncloud min-version="10.2" max-version="11" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<use-migrations>true</use-migrations>
 </info>

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "v1.3.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24"
+                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/67f9d314dc7ecf7245b8637906e151ccc62b8d24",
-                "reference": "67f9d314dc7ecf7245b8637906e151ccc62b8d24",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/62fef740245a85f00665e81ea8f0aa0b72afe6e7",
+                "reference": "62fef740245a85f00665e81ea8f0aa0b72afe6e7",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "composer/composer": "dev-master",
-                "symfony/console": "^2.5 || ^3.0 || ^4.0"
+                "symfony/console": "^2.5 || ^3.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -44,7 +44,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2019-03-17T12:38:04+00:00"
+            "time": "2017-09-11T13:13:58+00:00"
         }
     ],
     "aliases": [],

--- a/lib/Mailer/NotificationMailerAdapter.php
+++ b/lib/Mailer/NotificationMailerAdapter.php
@@ -25,6 +25,7 @@ use OCP\Notification\INotification;
 use OCP\IUserManager;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCA\Notifications\Mailer\NotificationMailer;
 
 /**
  * Send notifications via mail. This class acts as an adapter of the NotificationMailer and the

--- a/tests/Unit/AppInfo/ApplicationTest.php
+++ b/tests/Unit/AppInfo/ApplicationTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\Notifications\Tests\Unit\AppInfo;
 
+use OC\AppFramework\DependencyInjection\DIContainer;
 use OCA\Notifications\AppInfo\Application;
 use OCA\Notifications\Handler;
 use OCA\Notifications\Tests\Unit\TestCase;

--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -15,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License,
- * version 3, along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
 

--- a/tests/acceptance/features/lib/Notification.php
+++ b/tests/acceptance/features/lib/Notification.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * PageObject for a single notification
+ */
+class Notification extends OwncloudPage {
+	
+	/**
+	 *
+	 * @var NodeElement
+	 */
+	private $notificationElement;
+	
+	private $buttonByTextXpath = "//button[text()='%s']";
+	private $notificationLinkXpath = "//a[@class='notification-link']";
+	
+	/**
+	 * sets the NodeElement for the current notification
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("Notification")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $notificationElement
+	 *
+	 * @return void
+	 */
+	public function setElement(NodeElement $notificationElement) {
+		$this->notificationElement = $notificationElement;
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @throws ElementNotFoundException
+	 *
+	 * @return void
+	 */
+	public function followLink(
+		Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
+		$link = $this->notificationElement->find(
+			"xpath", $this->notificationLinkXpath
+		);
+		if ($link === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ . " could not find notification link " .
+				"with xpath " . $this->notificationLinkXpath
+			);
+		}
+		$destination = $link->getAttribute('href');
+		$link->click();
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($destination === $session->getCurrentUrl()) {
+				break;
+			}
+			$currentTime = \microtime(true);
+		}
+	}
+
+	/**
+	 *
+	 * @param string $reaction
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function react($reaction, Session $session) {
+		$buttonXpath = \sprintf($this->buttonByTextXpath, $reaction);
+		$button = $this->notificationElement->find(
+			"xpath", $buttonXpath
+		);
+		if ($button === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath " . $buttonXpath .
+				" could not find button with the given text"
+			);
+		}
+		$button->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+}


### PR DESCRIPTION
As we are decouple the bundled app release cycles from core, we should get rid of stable10 and only work on master.

I noticed some differences between stable10 and master so I thought I'd just merge stable10 into master, so we also get all the v10.x.x tags there.

Not sure if this is the right approach, let me know.

I had to resolve some conflicts and pick the right choice in some places.