### PR TITLE
[stable10] Fixes #129 - only set icon in case an icon is available

### DIFF
--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -297,7 +297,7 @@ class Handler {
 		if ($row['link'] !== '' && $row['link'] !== null) {
 			$notification->setLink($row['link']);
 		}
-		if (\method_exists($notification, 'setIcon') && $row['icon'] !== '' && $row['icon'] !== null) {
+		if (\method_exists($notification, 'setIcon') && isset($row['icon']) && $row['icon'] !== '' && $row['icon'] !== null) {
 			$notification->setIcon($row['icon']);
 		}
 


### PR DESCRIPTION
Backport #130 

This was missing from `stable10` branch of notifications app.