### PR TITLE
correct test step to send also the username when creating notification

### DIFF
--- a/tests/acceptance/features/apiNotifications/statuscodes.feature
+++ b/tests/acceptance/features/apiNotifications/statuscodes.feature
@@ -2,8 +2,8 @@
 Feature: statuscodes
 
   Background:
-    Given user "test1" has been created with default attributes and skeleton files
-    And as user "test1"
+    Given user "user1" has been created with default attributes and skeleton files
+    And as user "user1"
     And using OCS API version "2"
 
   Scenario: Status code when reading notifications with notifiers and without notifications
@@ -12,15 +12,15 @@ Feature: statuscodes
     And the list of notifications should have 0 entries
 
   Scenario: Status code when reading notifications with notifiers and notification
-    Given user "test1" has been sent a notification
+    Given user "user1" has been sent a notification
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/notifications/api/v1/notifications?format=json"
     Then the HTTP status code should be "200"
     And the list of notifications should have 1 entry
 
   Scenario: Status code when reading notifications with notifiers and notifications
-    Given user "test1" has been sent a notification
-    And user "test1" has been sent a notification
-    And user "test1" has been sent a notification
+    Given user "user1" has been sent a notification
+    And user "user1" has been sent a notification
+    And user "user1" has been sent a notification
     When the user sends HTTP method "GET" to OCS API endpoint "/apps/notifications/api/v1/notifications?format=json"
     Then the HTTP status code should be "200"
     And the list of notifications should have 3 entries

--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -58,9 +58,12 @@ class NotificationsContext implements Context {
 	 * @return void
 	 */
 	public function userIsSentANotification($user) {
-		$this->ocsContext->userSendsToOcsApiEndpoint(
+		$bodyTable = new TableNode([['user', $user]]);
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
-			'POST', '/apps/testing/api/v1/notifications'
+			'POST', '/apps/testing/api/v1/notifications',
+			$bodyTable,
+			null
 		);
 	}
 


### PR DESCRIPTION
The test-step did never send the username in the post-request, so it would only work with the user "test1", because that is what the testing app uses as default to create the notification