### PR TITLE
Add `Hello` as translatable string to the mail templates

### DIFF
--- a/templates/mail/htmlmail.php
+++ b/templates/mail/htmlmail.php
@@ -11,7 +11,8 @@
 <tr>
 <td width="20px">&nbsp;</td>
 <td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
-Hello,<br>
+<?php p($l->t('Hello,')); ?>
+<br>
 <?php if ($_['message'] !== ''): ?>
 	<?php p($_['message']); ?>
 	<br><br>

--- a/templates/mail/plaintextmail.php
+++ b/templates/mail/plaintextmail.php
@@ -1,4 +1,5 @@
 <?php p($l->t('Hello,')); ?>
+
 <?php if ($_['message'] !== ''): ?>
 <?php print_unescaped($_['message']); ?>
 

--- a/templates/mail/plaintextmail.php
+++ b/templates/mail/plaintextmail.php
@@ -1,4 +1,4 @@
-Hello,
+<?php p($l->t('Hello,')); ?>
 <?php if ($_['message'] !== ''): ?>
 <?php print_unescaped($_['message']); ?>
 


### PR DESCRIPTION
`Hello` was hard coded in the mail templates.

Fixes https://github.com/owncloud/enterprise/issues/4067