### PR TITLE
Fix: Mail sender name

### DIFF
--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -46,6 +46,12 @@ class NotificationMailer {
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
+	
+	/** @var string */
+	protected $senderAddress;
+
+	/** @var string */
+	protected $senderName;
 
 	public function __construct(IManager $manager, IMailer $mailer, OptionsStorage $optionsStorage, IURLGenerator $urlGenerator) {
 		$this->manager = $manager;

--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -27,6 +27,8 @@ use OCP\Mail\IMailer;
 use OCP\Template;
 use OCA\Notifications\Configuration\OptionsStorage;
 use OCP\IURLGenerator;
+use OCP\Defaults;
+use OCP\Util;
 
 /**
  * The class will focus on sending notifications via email. In addition, some email-related
@@ -51,7 +53,22 @@ class NotificationMailer {
 		$this->optionsStorage = $optionsStorage;
 		$this->urlGenerator = $urlGenerator;
 	}
+	
+	protected function getSenderData($setting) {
+		if (empty($this->senderAddress)) {
+			$this->senderAddress = Util::getDefaultEmailAddress('no-reply');
+		}
+		if (empty($this->senderName)) {
+			$defaults = new Defaults();
+			$this->senderName = $defaults->getName();
+		}
 
+		if ($setting === 'email') {
+			return $this->senderAddress;
+		}
+		return $this->senderName;
+	}
+	
 	/**
 	 * Send a notification via email to the list of email addresses passed as parameter
 	 * @param INotification $notification the notification to be sent
@@ -74,6 +91,7 @@ class NotificationMailer {
 
 		$emailMessage = $this->mailer->createMessage();
 		$emailMessage->setTo([$emailAddress]);
+		$emailMessage->setFrom([$this->getSenderData('email') => $this->getSenderData('name')]);
 
 		$notificationLink = $notification->getLink();
 		$urlComponents = \parse_url($notificationLink);

--- a/lib/Mailer/NotificationMailer.php
+++ b/lib/Mailer/NotificationMailer.php
@@ -54,6 +54,11 @@ class NotificationMailer {
 		$this->urlGenerator = $urlGenerator;
 	}
 	
+	/**
+	 * Get the sender data
+	 * @param string $setting Either `email` or `name`
+	 * @return string
+	 */
 	protected function getSenderData($setting) {
 		if (empty($this->senderAddress)) {
 			$this->senderAddress = Util::getDefaultEmailAddress('no-reply');


### PR DESCRIPTION
Displays the configured sender name and no longer just the email address.
Behaviour has been adapted to the [Activity App](https://github.com/owncloud/activity/blob/12a7ffe4566e6a5a55a95570f62306c2819edef5/lib/MailQueueHandler.php#L195-L208).