### PR TITLE
Provide get/list api link resource as absolute url

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -50,7 +50,8 @@ class Application extends App {
 				),
 				$server->getNotificationManager(),
 				$server->getConfig(),
-				$server->getUserSession()
+				$server->getUserSession(),
+				$server->getURLGenerator()
 			);
 		});
 

--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -225,7 +225,7 @@ class EndpointController extends OCSController {
 	 * @param string $link
 	 * @return string
 	 */
-	public function getAbsoluteLink(string $link) {
+	protected function getAbsoluteLink(string $link) {
 		$urlComponents = \parse_url($link);
 
 		// Check if already absolute

--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -27,6 +27,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Notification\IAction;
@@ -46,6 +47,9 @@ class EndpointController extends OCSController {
 	/** @var IConfig */
 	private $config;
 
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -53,14 +57,16 @@ class EndpointController extends OCSController {
 	 * @param IManager $manager
 	 * @param IConfig $config
 	 * @param IUserSession $session
+	 * @param IURLGenerator $urlGenerator
 	 */
-	public function __construct($appName, IRequest $request, Handler $handler, IManager $manager, IConfig $config, IUserSession $session) {
+	public function __construct($appName, IRequest $request, Handler $handler, IManager $manager, IConfig $config, IUserSession $session, IURLGenerator $urlGenerator) {
 		parent::__construct($appName, $request);
 
 		$this->handler = $handler;
 		$this->manager = $manager;
 		$this->config = $config;
 		$this->session = $session;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -176,7 +182,7 @@ class EndpointController extends OCSController {
 			'object_id' => $notification->getObjectId(),
 			'subject' => $notification->getParsedSubject(),
 			'message' => $notification->getParsedMessage(),
-			'link' => $notification->getLink(),
+			'link' => $this->getAbsoluteLink($notification->getLink()),
 			'actions' => [],
 		];
 		if (\method_exists($notification, 'getIcon')) {
@@ -197,7 +203,7 @@ class EndpointController extends OCSController {
 	protected function actionToArray(IAction $action) {
 		return [
 			'label' => $action->getParsedLabel(),
-			'link' => $action->getLink(),
+			'link' => $this->getAbsoluteLink($action->getLink()),
 			'type' => $action->getRequestType(),
 			'primary' => $action->isPrimary(),
 		];
@@ -213,5 +219,20 @@ class EndpointController extends OCSController {
 		}
 
 		return (string) $user;
+	}
+
+	/**
+	 * @param string $link
+	 * @return string
+	 */
+	public function getAbsoluteLink(string $link) {
+		$urlComponents = \parse_url($link);
+
+		// Check if already absolute
+		if (!isset($urlComponents['host'])) {
+			$link = $this->urlGenerator->getAbsoluteURL($link);
+		}
+
+		return $link;
 	}
 }

--- a/tests/Unit/Controller/EndpointControllerTest.php
+++ b/tests/Unit/Controller/EndpointControllerTest.php
@@ -23,6 +23,7 @@
 namespace OCA\Notifications\Tests\Unit\Controller;
 
 use OC\OCS\Result;
+use OC\URLGenerator;
 use OCA\Notifications\Controller\EndpointController;
 use OCA\Notifications\Tests\Unit\TestCase;
 use OCP\AppFramework\Http;
@@ -48,6 +49,9 @@ class EndpointControllerTest extends TestCase {
 
 	/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
+
+	/** @var \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
+	protected $urlGenerator;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -82,6 +86,11 @@ class EndpointControllerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		/** @var \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
+		$this->urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->session->expects($this->any())
 			->method('getUser')
 			->willReturn($this->user);
@@ -99,7 +108,8 @@ class EndpointControllerTest extends TestCase {
 				$this->handler,
 				$this->manager,
 				$this->config,
-				$this->session
+				$this->session,
+				$this->urlGenerator
 			);
 		} else {
 			return $this->getMockBuilder('OCA\Notifications\Controller\EndpointController')
@@ -109,7 +119,8 @@ class EndpointControllerTest extends TestCase {
 					$this->handler,
 					$this->manager,
 					$this->config,
-					$this->session
+					$this->session,
+					$this->urlGenerator
 				])
 				->setMethods($methods)
 				->getMock();
@@ -414,9 +425,14 @@ class EndpointControllerTest extends TestCase {
 			->method('getParsedActions')
 			->willReturn($actions);
 
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteUrl')
+			->willReturn($link);
+
 		$controller = $this->getController([
 			'actionToArray'
 		]);
+
 		$controller->expects($this->exactly(\sizeof($actions)))
 			->method('actionToArray')
 			->willReturn('action');
@@ -474,6 +490,10 @@ class EndpointControllerTest extends TestCase {
 		$action->expects($this->once())
 			->method('isPrimary')
 			->willReturn($isPrimary);
+
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteUrl')
+			->willReturn($link);
 
 		$this->assertEquals(
 			[


### PR DESCRIPTION
Transform relative URLs to absolute URLs for API endpoints to ensure compatibility with other clients.

Fixes: 
- https://github.com/owncloud/core/issues/38888