### PR TITLE
[tests-only] Send the correct string to substituteInLineCodes

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -122,8 +122,8 @@ class NotificationsContext implements Context {
 		$rows = $formData->getRows();
 		$rows[] = ["user", $user];
 		for ($rowCount = 0; $rowCount < \count($rows); $rowCount ++) {
-			$rows[$rowCount] = $this->featureContext->substituteInLineCodes(
-				$rows[$rowCount]
+			$rows[$rowCount][1] = $this->featureContext->substituteInLineCodes(
+				$rows[$rowCount][1]
 			);
 		}
 		$formData = new TableNode($rows);


### PR DESCRIPTION
See errors in nightly like: https://drone.owncloud.com/owncloud/notifications/1693/14/10
```
  Scenario: Create notifications                                             # /var/www/owncloud/testrunner/apps/notifications/tests/acceptance/features/webUINotifications/displayNotificationsOnWebUI.feature:16
    When user "Alice" is sent a notification with                            # NotificationsContext::userIsSentANotificationWith()
      | app         | notificationsacceptancetesting |
      | timestamp   | 144958517                      |
      | subject     | Acceptance Testing             |
      | link        | https://owncloud.org/blog      |
      | message     | Notifications in ownCloud      |
      | object_type | blog                           |
      | object_id   | 9483                           |
      Warning: strpos() expects parameter 1 to be string, array given in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/FeatureContext.php line 2842
```

Recent changes in core to `substituteInLineCodes` actually need the `$value` passed to be a string, which it was always supposed to be. The changes have highlighted a bug in this Notifications acceptance test code.