### PR TITLE
[CI] dont run acceptance tests with oracle database

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -60,7 +60,6 @@ config = {
             "databases": [
                 "mysql:8.0",
                 "postgres:9.4",
-                "oracle",
             ],
             # Note: this is required because tests/acceptance/run.sh disables notifications by default
             "extraEnvironment": {


### PR DESCRIPTION
In CI we still run acceptance tests with oracle database
In other apps and oc10 core we only run unit tests with oracle database. 
so to make it consistent remove acceptance tests with oracle database in CI.