### PR TITLE
[tests-only] Save exitcode of last occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -368,8 +368,10 @@ class NotificationsContext implements Context {
 			if (\array_key_exists("link", $content)) {
 				$cmd = $cmd . " -l {$content['link']}";
 			}
-			$this->featureContext->runOcc(
-				[$cmd]
+			$this->featureContext->setOccLastCode(
+				$this->featureContext->runOcc(
+					[$cmd]
+				)
 			);
 		}
 	}


### PR DESCRIPTION
## Description
The PR https://github.com/owncloud/core/pull/40359 has implemented different method to save the exitcode of the last occ command and the local tests were failing because the exitcode was not saved.
In this PR, I have implemented the updated way to save the occ exitCode.


## Related Issue
Fixes https://github.com/owncloud/notifications/issues/366
