### PR TITLE
[tests-only] [full-ci] Change mailhog test tag to email

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,6 @@
 BANST_AWS_CLI = "banst/awscli"
 DRONE_CLI = "drone/cli:alpine"
-MAILHOG_MAILHOG = "mailhog/mailhog"
+INBUCKET_INBUCKET = "inbucket/inbucket"
 MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
@@ -1119,7 +1119,7 @@ def acceptance(ctx):
                         makeParameter = "test-acceptance-cli"
 
                 if testConfig["emailNeeded"]:
-                    environment["MAILHOG_HOST"] = "email"
+                    environment["EMAIL_HOST"] = "email"
 
                 if testConfig["ldapNeeded"]:
                     environment["TEST_WITH_LDAP"] = True
@@ -1438,7 +1438,7 @@ def emailService(emailNeeded):
     if emailNeeded:
         return [{
             "name": "email",
-            "image": MAILHOG_MAILHOG,
+            "image": INBUCKET_INBUCKET,
         }]
 
     return []
@@ -1449,7 +1449,7 @@ def waitForEmailService(emailNeeded):
             "name": "wait-for-email",
             "image": OC_CI_WAIT_FOR,
             "commands": [
-                "wait-for -it email:8025 -t 600",
+                "wait-for -it email:9000 -t 600",
             ],
         }]
 

--- a/tests/acceptance/features/apiNotifications/email-notifications.feature
+++ b/tests/acceptance/features/apiNotifications/email-notifications.feature
@@ -1,4 +1,4 @@
-@api @mailhog
+@api @email
 Feature: notifications-content
 
   Background:


### PR DESCRIPTION
https://github.com/owncloud/core/pull/40442 changed the email server used in tests from mailhog to inbucket. It also changed the tag used in feature files from `@mailhog` to `@email`

So make the same change here.

Issue https://github.com/owncloud/QA/issues/771
