### PR TITLE
[tests-only] [full-ci] Run phan with PHP 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -393,6 +393,7 @@ def phan(ctx):
 
     default = {
         "phpVersions": [DEFAULT_PHP_VERSION],
+        "extraApps": {},
     }
 
     if "defaults" in config:
@@ -431,6 +432,7 @@ def phan(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "lint") +
                          installCore(ctx, "daily-master-qa", "sqlite", False) +
+                         installExtraApps(phpVersion, params["extraApps"], False) +
                          [
                              {
                                  "name": "phan",
@@ -1162,6 +1164,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1462,6 +1465,26 @@ def waitForEmailService(emailNeeded):
 
     return []
 
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
+            ],
+        }]
+
+    return []
+
 def ldapService(ldapNeeded):
     if ldapNeeded:
         return [{
@@ -1688,7 +1711,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         ] if not useBundledApp else []),
     }]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, enableExtraApps = True):
     commandArray = []
     for app, command in extraApps.items():
         commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
@@ -1697,9 +1720,10 @@ def installExtraApps(phpVersion, extraApps):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)
         commandArray.append("cd %s" % dir["server"])
-        commandArray.append("php occ a:l")
-        commandArray.append("php occ a:e %s" % app)
-        commandArray.append("php occ a:l")
+        if (enableExtraApps):
+            commandArray.append("php occ a:l")
+            commandArray.append("php occ a:e %s" % app)
+            commandArray.append("php occ a:l")
 
     if (commandArray == []):
         return []

--- a/.drone.star
+++ b/.drone.star
@@ -47,7 +47,14 @@ config = {
     ],
     "codestyle": True,
     "phpstan": True,
-    "phan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "javascript": False,
     "phpunit": True,
     "acceptance": {

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.
