### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -66,8 +66,10 @@ class Generate extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
+	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getOption('user');
 		$group = $input->getOption('group');
 		if ($user === null && $group === null) {

--- a/lib/Command/RepairNotifications.php
+++ b/lib/Command/RepairNotifications.php
@@ -58,7 +58,7 @@ class RepairNotifications extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$subject = $input->getArgument('subject');
 
 		if (!\in_array($subject, self::$availableSubjects)) {


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630