### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/appinfo/Migrations/Version20170801152524.php
+++ b/appinfo/Migrations/Version20170801152524.php
@@ -11,7 +11,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20170801152524 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}notifications");
+		$table = $schema->getTable("{$prefix}notifications");
 		if ($table->hasColumn('icon')) {
 			return;
 		}

--- a/appinfo/Migrations/Version20180119080933.php
+++ b/appinfo/Migrations/Version20180119080933.php
@@ -12,7 +12,7 @@ class Version20180119080933 implements ISchemaMigration {
 	 */
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}notifications");
+		$table = $schema->getTable("{$prefix}notifications");
 		$column = $table->getColumn('message');
 		$column->setNotnull(false);
 		$column = $table->getColumn('link');


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
