### PR TITLE
chore: add Makefile target ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ else
 endif
 	tar --format=gnu --owner=nobody --group=nogroup -czf $(appstore_package_name).tar.gz -C $(appstore_package_name)/../ $(app_name)
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor
+	@echo dependencies and build actions for CI are completed
+
 ##------------
 ## Tests
 ##------------


### PR DESCRIPTION
This is used by the acceptance GitHub workflow.
It needs to exist in the notifications app so that the notifications app can be added as a test case in https://github.com/owncloud/reusable-workflows/pull/58

Then when the updated acceptance workflow is merged, I will make a PR similar to #394 to use the new acceptance workflow here.