### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,9 @@
-## Submitting issues
+# Contributing
 
-If you have questions about how to install or use ownCloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
+Thank you for your interest in contributing to this project!
 
-### Short version
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
 
- * The [**issue template can be found here**][template]. Please always use the issue template when reporting issues.
-
-### Guidelines
-* Please search the existing issues first, it's likely that your issue was already reported or even fixed.
-  - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
-  - You can also filter by appending e. g. "state:open" to the search string.
-  - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
-* This repository ([Notifications](https://github.com/owncloud/notifications/issues)) is *only* for issues within the ownCloud Announcement Center code.
-* __SECURITY__: Report any potential security bug to security@owncloud.com following our [security policy](https://owncloud.org/security/) instead of filing an issue in our bug tracker
-* Report the issue using our [template][template], it includes all the information we need to track down the issue.
-
-Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
-
-[template]: https://raw.github.com/owncloud/core/master/issue_template.md
-[mailinglist]: https://mailman.owncloud.org/mailman/listinfo/owncloud
-[forum]: https://forum.owncloud.org/
-[irc]: https://webchat.freenode.net/?channels=owncloud&uio=d4
-
-### Contribute Code and translations
-Please check [core's contribution guidelines](https://github.com/owncloud/core/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,127 @@
 # Notifications
 
-Notification backend and UI for the notification panel/icon.
-Used for notifications of other apps ([announcementcenter](https://github.com/owncloud/announcementcenter), [federatedfilesharing](https://github.com/owncloud/core/tree/master/apps/federatedfilesharing) etc.)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-## QA metrics on master branch:
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](COPYING) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/notifications/status.svg?branch=master)](https://drone.owncloud.com/owncloud/notifications)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_notifications&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_notifications)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_notifications&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_notifications)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_notifications&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_notifications)
+The notifications backend and UI for ownCloud Server. It provides the notification bell/panel in the web interface and an OCS REST API that other ownCloud apps (such as announcementcenter and federatedfilesharing) use to create, display, and manage user notifications.
 
-## Screenshots
+## Getting Started
 
-### No notifications (Sample)
+Follow the steps below to install and enable the Notifications app.
 
-**Note:**
-In ownCloud 8.2 the app hides itself, when there is no app registered,
-that creates notifications. In this case the bell and the dropdown are not
-accessible.
+### Prerequisites
 
-![Build Status](img/sample-empty.png)
+- ownCloud Server 10.x
+- PHP 7.4+
 
-### New notifications (Sample)
+### Installation
 
-![Build Status](img/sample-new.png)
+This app is typically bundled with ownCloud Server. To install manually:
 
-## Notification workflow
+```bash
+git clone https://github.com/owncloud/notifications.git /var/www/owncloud/apps/notifications
+occ app:enable notifications
+```
 
-For information how to make your app interact with the notifications app, see
-[Sending and processing/"mark as read" notifications as an ownCloud App](https://github.com/owncloud/notifications/blob/master/docs/notification-workflow.md)
-in the wiki.
+### Build
 
-If you want to present notifications as a client, see [Reading and deleting notifications as an ownCloud Client](https://github.com/owncloud/notifications/blob/master/docs/ocs-endpoint-v1.md).
+```bash
+make dist
+```
+
+### Run Tests
+
+```bash
+make test-php-unit
+make test-php-style
+```
+
+## Documentation
+
+- [Notification Workflow (for app developers)](https://github.com/owncloud/notifications/blob/master/docs/notification-workflow.md)
+- [OCS Endpoint v1 (for client developers)](https://github.com/owncloud/notifications/blob/master/docs/ocs-endpoint-v1.md)
+
+## Part of ownCloud Server (Classic)
+
+This app provides the core notification infrastructure for [ownCloud Server 10](https://github.com/owncloud/core). Other apps register notification providers through this app's API.
+
+The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/notifications)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](COPYING).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,62 @@
+# agents.md -- Notifications
+
+## Repository Overview
+
+Notification backend and UI for ownCloud Server. Provides the notification infrastructure that other apps use to create and display user notifications. Licensed under AGPL-3.0.
+
+## Architecture & Key Paths
+
+- `lib/` -- PHP application logic
+- `js/` -- Frontend JavaScript (notification panel)
+- `css/` -- Stylesheets
+- `templates/` -- Server-side templates
+- `appinfo/` -- ownCloud app metadata
+- `l10n/` -- Translation files
+- `docs/` -- Developer documentation (API reference)
+- `tests/` -- Unit tests
+- `Makefile` -- Build and test automation
+- `composer.json` -- PHP dependencies
+
+## Development Conventions
+
+- PHP code follows ownCloud coding standards (phpcs)
+- Static analysis with PHPStan and Phan
+
+## Build & Test Commands
+
+```bash
+make dist                     # Build distribution package
+make test-php-unit            # Run PHP unit tests
+make test-php-style           # Check PHP code style
+make test-php-phpstan         # Run PHPStan static analysis
+make test-acceptance-api      # Run API acceptance tests
+```
+
+## Important Constraints
+
+- Licensed under AGPL-3.0 (copyleft). Apache 2.0 migration planned.
+- Other OC10 apps depend on this app's notification API.
+- All contributions require a DCO sign-off.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+This app provides both the UI (bell icon/dropdown) and the backend API for notifications. Other apps register notification providers. The `docs/` directory contains the notification workflow and OCS endpoint documentation.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>